### PR TITLE
change unsafe_view to view

### DIFF
--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -134,7 +134,7 @@ function update_centers!{T<:FloatingPoint}(
     for i = 1 : k
         if to_update[i]
             @inbounds ci::T = 1 / cweights[i]
-            multiply!(unsafe_view(centers,:,i), ci)
+            multiply!(view(centers,:,i), ci)
         end
     end
 end
@@ -169,7 +169,7 @@ function update_centers!{T<:FloatingPoint}(
     for i = 1 : k
         if to_update[i]
             @inbounds ci::T = 1 / cweights[i]
-            multiply!(unsafe_view(centers,:,i), ci)
+            multiply!(view(centers,:,i), ci)
         end
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,8 +21,8 @@ function accumulate_cols!(
 		@inbounds cj = c[j]
 		1 <= cj <= K || error("assignment out of boundary.")
 
-		rj = unsafe_view(r, :, cj)
-		xj = unsafe_view(x, :, j)
+		rj = view(r, :, cj)
+		xj = view(x, :, j)
 		if rw[cj] > 0
 			add!(rj, xj)
 		else
@@ -54,8 +54,8 @@ function accumulate_cols!(
 			@inbounds cj = c[j]
 			1 <= cj <= K || error("assignment out of boundary.")
 
-			rj = unsafe_view(r, :, cj)
-			xj = unsafe_view(x, :, j)
+			rj = view(r, :, cj)
+			xj = view(x, :, j)
 			if rw[cj] > 0
 				fma!(rj, xj, wj)
 			else
@@ -86,8 +86,8 @@ function accumulate_cols_u!(
 		1 <= cj <= K || error("assignment out of boundary.")
 
 		if u[cj]
-			rj = unsafe_view(r, :, cj)
-			xj = unsafe_view(x, :, j)
+			rj = view(r, :, cj)
+			xj = view(x, :, j)
 			if rw[cj] > 0
 				add!(rj, xj)
 			else
@@ -122,8 +122,8 @@ function accumulate_cols_u!(
 			1 <= cj <= K || error("assignment out of boundary.")
 			
 			if u[cj]
-				rj = unsafe_view(r, :, cj)
-				xj = unsafe_view(x, :, j)
+				rj = view(r, :, cj)
+				xj = view(x, :, j)
 				if rw[cj] > 0
 					fma!(rj, xj, wj)
 				else


### PR DESCRIPTION
I pulled the latest julia and clustering package and saw some deprecation warnings to change the unsafe_view function to use the view function. I ran the tests and it seems to still work.
