### PR TITLE
PR: memory efficient DBSCAN clustering

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,5 @@ julia 0.3
 ArrayViews 0.6.0
 Distances 0.2.0
 StatsBase 0.7.0
+NearestNeighbors
 Compat

--- a/src/dbscan.jl
+++ b/src/dbscan.jl
@@ -102,4 +102,86 @@ function _dbs_expand_cluster!{T<:Real}(D::DenseMatrix{T},           # distance m
     return cnt
 end
 
+using NearestNeighbors
 
+
+immutable Cluster
+  size::Int64
+  core_indices::Array{Int64, 1}
+  boundary_indices::Array{Int64, 1}
+end
+
+
+function _update_exploration_list!{T <: Unsigned, U <: Unsigned}(adj_list::Array{T}, exploration_list::Vector{U}, visited::Vector{Bool})
+  for j in adj_list
+    visited[j] && continue
+    push!(exploration_list, j)
+  end
+end
+
+
+function _except_cluster!(clusters::Vector{Cluster}, core_selection::Vector{Bool}, cluster_selection::Vector{Bool})
+    core_idx = find(core_selection) # index list of the core members
+    boundary_idx = find(cluster_selection & ~core_selection) # index list of the boundary members
+    push!(clusters, Cluster(sum(cluster_selection), core_idx, boundary_idx))
+end
+
+"""
+
+"""
+function dbscan{T <: Real, N <: Unsigned}(points::Array{T,N}, radius::AbstractFloat, min_neighbors::Unsigned; min_cluster_size::Unsigned=1)
+  dim, num_points = size(points)
+  num_points <= dim && error("points must be a D x N matrix with more points than dimentions")
+  0 < radius || error("radius must be a positive real value.")
+  1 <= min_neighbors || error("minpts must be a positive integer.")
+  1 <= min_cluster_size || error("min_cluster_size must be a positive integer.")
+  return  _dbscan(points, radius, min_neighbors; min_cluster_size)
+end
+
+
+"""
+dbscan(points, radius, min_neighbors, min_cluster_size)
+
+Input:
+  points[Float64]: DxN matrix of N points in D dimensions
+  radius Float64: environment radius
+  min_neighbors Int64: minimum number of neightbors to be a core point
+  min_cluster_size Int64: minimum number of points to be a valid cluster
+
+Output:
+  Array[Cluster]: an array of clusters with the id, size core indices and boundary indices
+"""
+function _dbscan(points, radius, min_neighbors, min_cluster_size)
+
+  num_points = size(points, 2)
+  clusters = Vector{Cluster}(0)
+
+  visited = zeros(Bool, num_points)
+  cluster_selection = zeros(Bool, num_points)
+  core_selection = zeros(Bool, num_points)
+
+  to_explore = Vector{Int64}(0)
+
+  kdtree = KDTree(points; leafsize=20)
+  for i=1:num_points
+    visited[i] && continue
+    push!(to_explore, i) # start a new cluster
+    core_selection[:] = false
+    cluster_selection[:] = false
+    cluster_selection[i] = true
+    while !isempty(to_explore)
+      current_index = shift!(to_explore)
+      visited[current_index] && continue
+      visited[current_index] = true
+      adj_list = inrange(kdtree, points[:, current_index], radius)
+      cluster_selection[adj_list] = true # all the neighbors are part of the cluster
+      # if a point doesn't have enough neighbours it is not a 'core' point and its neighbours are not added to the to_explore list
+      length(adj_list) <= min_neighbors && continue
+      core_selection[current_index] = true
+      _update_exploration_list!(adj_list, to_explore, visited)
+    end
+    cluster_size = sum(cluster_selection)
+    min_cluster_size <= cluster_size && _except_cluster!(clusters, cluster_selection, core_selection)
+  end
+  return clusters
+end


### PR DESCRIPTION
The existing DBSCAN uses a full adjacency matrix which blows the memory when a large number of points is used. Here is an implementation that build an adjacency list on the fly. Also it reports the indices of both the core points of each cluster and the boundary points which can belong to multiple clusters. 