### PR TITLE
Remove inexact exception in favor of values pruning in MCL

### DIFF
--- a/src/mcl.jl
+++ b/src/mcl.jl
@@ -82,16 +82,16 @@ function _mcl_expand(src::AbstractMatrix, expansion::Number)
     end
 end
 
-# integral power inflation
-el_inflate(el::Number, inflation::Integer) = el^inflation
+# integral power inflation (single matrix element)
+_mcl_el_inflate(el::Number, inflation::Integer) = el^inflation
 
-# non-integral power inflation
-el_inflate(el::Number, inflation::Number) = real((el+0im)^inflation)
+# non-integral power inflation (single matrix element)
+_mcl_el_inflate(el::Number, inflation::Number) = real((el+0im)^inflation)
 
 # adjacency matrix inflation (element-wise raising to a given power) kernel
 function _mcl_inflate!(dest::AbstractMatrix, src::AbstractMatrix, inflation::Number)
     @inbounds for i in eachindex(src)
-        dest[i] = el_inflate(src[i], inflation)
+        dest[i] = _mcl_el_inflate(src[i], inflation)
     end
 end
 

--- a/src/mcl.jl
+++ b/src/mcl.jl
@@ -5,8 +5,8 @@
 
 Result returned by `mcl()`.
 """
-immutable MCLResult{T<:Real} <: ClusteringResult
-    mcl_adj::AbstractMatrix{T}    # final MCL adjacency matrix (equilibrium state matrix if converged)
+immutable MCLResult <: ClusteringResult
+    mcl_adj::AbstractMatrix     # final MCL adjacency matrix (equilibrium state matrix if converged)
     assignments::Vector{Int}    # element-to-cluster assignments (n)
     counts::Vector{Int}         # number of samples assigned to each cluster (k)
     nunassigned::Int            # number of single elements not assigned to any cluster
@@ -96,7 +96,7 @@ function _mcl_inflate!(dest::AbstractMatrix, src::AbstractMatrix, inflation::Num
 end
 
 # adjacency matrix pruning
-function _mcl_prune!{T<:Number}(mtx::AbstractMatrix{T}, prune_tol::Number)
+function _mcl_prune!(mtx::AbstractMatrix, prune_tol::Number)
     for i in 1:size(mtx,2)
         c = view(mtx, :, i)
         θ = mean(c)*prune_tol
@@ -201,6 +201,6 @@ function mcl{T<:Real}(adj::AbstractMatrix{T};
     el2clu, clu_sizes, nunassigned = _mcl_clusters(mcl_adj, allow_singles,
                                                    tol/length(mcl_adj))
 
-    return MCLResult{T}(save_final_matrix ? mcl_adj : similar(mcl_adj, (0,0)),
+    return MCLResult(save_final_matrix ? mcl_adj : similar(mcl_adj, (0,0)),
               el2clu, clu_sizes, nunassigned, niter, rel_delta, converged)
 end

--- a/src/mcl.jl
+++ b/src/mcl.jl
@@ -134,7 +134,7 @@ Ref: Stijn van Dongen, "Graph clustering by flow simulation", 2001
 """
 function mcl{T<:Real}(adj::AbstractMatrix{T};
                       add_loops::Bool = true,
-                      expansion::Number = 2, inflation::Number = 2.0,
+                      expansion::Number = 2, inflation::Number = 2,
                       save_final_matrix::Bool = false,
                       allow_singles::Bool = true,
                       max_iter::Integer = 100, tol::Number=1.0e-5,

--- a/test/mcl.jl
+++ b/test/mcl.jl
@@ -64,10 +64,11 @@ res = mcl(sparse(adj_matrix), display=:none, expansion=2)
 @test isa(res, MCLResult)
 @test length(res.assignments) == length(nodes)
 @test res.nunassigned == 0
+@test eltype(res.mcl_adj) === Float64
 
 @test_throws ArgumentError mcl(sparse(adj_matrix), display=:none, expansion=2.1)
 
 # use Float32 input
 res = mcl(convert(Matrix{Float32},adj_matrix), display=:none, expansion=2)
-@test isa(res, MCLResult{Float32})
+@test isa(res, MCLResult)
 @test eltype(res.mcl_adj) === Float32

--- a/test/mcl.jl
+++ b/test/mcl.jl
@@ -58,3 +58,16 @@ res = mcl(diagm([1.0, 1.0]), display=:none, allow_singles=false)
 @test length(res.counts) == 0
 @test res.assignments == [0, 0]
 @test res.nunassigned == 2
+
+# use sparse matrix
+res = mcl(sparse(adj_matrix), display=:none, expansion=2)
+@test isa(res, MCLResult)
+@test length(res.assignments) == length(nodes)
+@test res.nunassigned == 0
+
+@test_throws ArgumentError mcl(sparse(adj_matrix), display=:none, expansion=2.1)
+
+# use Float32 input
+res = mcl(convert(Matrix{Float32},adj_matrix), display=:none, expansion=2)
+@test isa(res, MCLResult{Float32})
+@test eltype(res.mcl_adj) === Float32

--- a/test/mcl.jl
+++ b/test/mcl.jl
@@ -35,6 +35,12 @@ end
 @test res.nunassigned == 0
 @test res.assignments == [1, 2, 1, 2, 1, 2]
 
+# test with integer inflation value
+res = mcl(adj_matrix, display=:none, inflation=2)
+@test isa(res, MCLResult)
+@test length(res.assignments) == length(nodes)
+@test res.nunassigned == 0
+
 # test non-integral expansion (show not raise an exception)
 res = mcl(adj_matrix, display=:none, inflation=1.5, expansion=1.5, save_final_matrix=true)
 @test isa(res, MCLResult)


### PR DESCRIPTION
Currently, if adjacency matrix values become small, during the inflation step, an inexact exception is thrown and algorithm is terminated. This PR removes this inexact exception, and substitutes it with a threshold pruning schema for column values which guarantees convergence of the algorithm.

This will fix #87 and recent CI test failures.

Ref: see 11.1.1 in "Graph clustering by flow simulation" by Stijn van Dongen.