### PR TITLE
Add PkgEvaluator link for Julia v0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 This package provides a set of algorithms for data clustering.
 
-[![0.4](http://pkg.julialang.org/badges/Clustering_0.4.svg)](http://pkg.julialang.org/?pkg=Clustering)
 [![0.5](http://pkg.julialang.org/badges/Clustering_0.5.svg)](http://pkg.julialang.org/?pkg=Clustering)
 [![0.6](http://pkg.julialang.org/badges/Clustering_0.6.svg)](http://pkg.julialang.org/?pkg=Clustering)
 [![Travis](https://travis-ci.org/JuliaStats/Clustering.jl.svg?branch=master)](https://travis-ci.org/JuliaStats/Clustering.jl)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This package provides a set of algorithms for data clustering.
 
 [![0.4](http://pkg.julialang.org/badges/Clustering_0.4.svg)](http://pkg.julialang.org/?pkg=Clustering)
 [![0.5](http://pkg.julialang.org/badges/Clustering_0.5.svg)](http://pkg.julialang.org/?pkg=Clustering)
+[![0.6](http://pkg.julialang.org/badges/Clustering_0.6.svg)](http://pkg.julialang.org/?pkg=Clustering)
 [![Travis](https://travis-ci.org/JuliaStats/Clustering.jl.svg?branch=master)](https://travis-ci.org/JuliaStats/Clustering.jl)
 [![Coveralls](https://coveralls.io/repos/github/JuliaStats/Clustering.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaStats/Clustering.jl?branch=master)
 


### PR DESCRIPTION
I can also remove Julia v0.4 link as it's quite outdated.

I'm about to tag v0.9.1 after this is merged: with #103 the tests are passing on v0.6 again.