### PR TITLE
refactoring of kmeans + type fixes

### DIFF
--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -204,7 +204,7 @@ function update_assignments!(dmat::Matrix{T},          # in:  distance matrix (k
         # find the closest cluster to the i-th sample. Note that a
         # is necessarily between 1 and size(dmat, 1) === k as a result
         # and can thus be used as an index in an `inbounds` environment
-        a = argmin(view(dmat, :, j))
+        c, a = findmin(view(dmat, :, j))
         c = dmat[a, j]
 
         # set/update the assignment

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -69,7 +69,7 @@ function kmeans(X::AbstractMatrix{<:Real},                # in: sample matrix (p
                 distance::SemiMetric=SqEuclidean())       # in: function to calculate distance with
     p, n = size(X)
     k = round(Int, k)
-    (2 <= k < n) || error("k must have 2 <= k < n.")
+    (2 <= k < n) || throw(ArgumentError("k must be 2 <= k < n, k=$k given."))
 
     # initialize the centers using a type wide enough so that the updates
     # centers[i, cj] += X[i, j] * wj will occur without loss of precision through rounding

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -48,13 +48,6 @@ function kmeans!(centers::AbstractMatrix{<:AbstractFloat}, # in: current centers
     assignments = Vector{Int}(undef, n)
     counts = Vector{Int}(undef, k)
 
-    # check the types to see wheter the updates: centers[i, cj] += X[i, j] * wj
-    # may occur loss of precision through silent casting
-    update_type = float(weights === nothing ? eltype(X) : typeof(one(eltype(X)) * one(eltype(weights))))
-    update_type <: eltype(centers) || @warn "The type of the centers update ($update_type) is " *
-                                            "wider than that of the given centers " *
-                                            "($(eltype(centers))). This may incur rounding errors."
-
     _kmeans!(X, weights, centers, assignments, counts,
              Int(maxiter), Float64(tol), display_level(display), distance)
 end

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -36,10 +36,10 @@ function kmeans!(X::AbstractMatrix{<:Real},                # in: sample matrix (
                  tol::Real=_kmeans_default_tol,            # in: tolerance of change at convergence
                  display::Symbol=_kmeans_default_display,  # in: level of display
                  distance::SemiMetric=SqEuclidean())       # in: function to compute distances
-    p, n = size(X)
-    p2, k = size(centers)
+    d, n = size(X)
+    dc, k = size(centers)
 
-    p == p2 || throw(DimensionMismatch("Inconsistent array dimensions for `X` and `centers`."))
+    d == dc || throw(DimensionMismatch("Inconsistent array dimensions for `X` and `centers`."))
     (2 <= k < n) || error("k must have 2 <= k < n.")
     if weights !== nothing
         length(weights) == n || throw(DimensionMismatch("Incorrect length of weights."))
@@ -64,7 +64,7 @@ function kmeans(X::AbstractMatrix{<:Real},                # in: sample matrix (d
                 tol::Real=_kmeans_default_tol,            # in: tolerance  of change at convergence
                 display::Symbol=_kmeans_default_display,  # in: level of display
                 distance::SemiMetric=SqEuclidean())       # in: function to calculate distance with
-    p, n = size(X)
+    d, n = size(X)
     k = round(Int, k)
     (2 <= k < n) || throw(ArgumentError("k must be 2 <= k < n, k=$k given."))
 
@@ -72,7 +72,7 @@ function kmeans(X::AbstractMatrix{<:Real},                # in: sample matrix (d
     # centers[i, cj] += X[i, j] * wj will occur without loss of precision through rounding
     T = float(weights === nothing ? eltype(X) : promote_type(eltype(X), eltype(weights)))
     iseeds = initseeds(init, X, k)
-    centers = copyseeds!(Matrix{T}(undef, p, k), X, iseeds)
+    centers = copyseeds!(Matrix{T}(undef, d, k), X, iseeds)
 
     kmeans!(X, centers;
             weights=weights, maxiter=Int(maxiter), tol=Float64(tol),
@@ -89,7 +89,7 @@ function _kmeans!(X::AbstractMatrix{<:Real},                # in: sample matrix 
                   tol::Float64,                             # in: tolerance of change at convergence
                   displevel::Int,                           # in: the level of display
                   distance::SemiMetric)                     # in: function to calculate distance
-    p, n = size(X)
+    d, n = size(X)
     k = size(centers, 2)
     to_update = Vector{Bool}(undef, k) # whether a center needs to be updated
     unused = Vector{Int}()

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -1,8 +1,6 @@
 # K-means algorithm
 
-####
-#### Result object
-####
+#### Interface
 
 # T is the eltype(centers)
 # D is the type of pairwise distance computation from samples to centers
@@ -23,10 +21,6 @@ const _kmeans_default_init = :kmpp
 const _kmeans_default_maxiter = 100
 const _kmeans_default_tol = 1.0e-6
 const _kmeans_default_display = :none
-
-####
-#### Exported kmeans and kmeans! functions
-####
 
 """
     kmeans!(centers, X)
@@ -95,11 +89,9 @@ function kmeans(X::AbstractMatrix{<:Real},                # in: sample matrix (p
             display=display, distance=distance)
 end
 
-
-####
 #### Core implementation
-####
 
+# core k-means skeleton
 function _kmeans!(X::AbstractMatrix{<:Real},                # in: sample matrix (p x n)
                   weights::Union{Nothing, Vector{<:Real}},  # in: sample weights (n)
                   centers::AbstractMatrix{<:AbstractFloat}, # in/out: matrix of centers (p x k)
@@ -188,10 +180,10 @@ function _kmeans!(X::AbstractMatrix{<:Real},                # in: sample matrix 
                         cweights, objv, t, converged)
 end
 
-####
-#### update assignments
-####
-
+#
+#  Updates assignments, costs, and counts based on
+#  an updated (squared) distance matrix
+#
 function update_assignments!(dmat::Matrix{T},          # in:  distance matrix (k x n)
                              is_init::Bool,            # in:  whether it is the initial run
                              assignments::Vector{Int}, # out: assignment vector (n)
@@ -250,10 +242,11 @@ function update_assignments!(dmat::Matrix{T},          # in:  distance matrix (k
     end
 end
 
-####
-#### update centers (unweighted case)
-####
-
+#
+#  Update centers based on updated assignments
+#
+#  (specific to the case where samples are not weighted)
+#
 function update_centers!(X::AbstractMatrix{<:Real},        # in: sample matrix (p x n)
                          weights::Nothing,                 # in: sample weights
                          assignments::Vector{Int},         # in: assignments (n)
@@ -295,10 +288,11 @@ function update_centers!(X::AbstractMatrix{<:Real},        # in: sample matrix (
     end
 end
 
-####
-#### update centers (weighted case)
-####
-
+#
+#  Update centers based on updated assignments
+#
+#  (specific to the case where samples are weighted)
+#
 function update_centers!(X::AbstractMatrix{<:Real}, # in: sample matrix (p x n)
                          weights::Vector{W},        # in: sample weights (n)
                          assignments::Vector{Int},  # in: assignments (n)
@@ -344,10 +338,9 @@ function update_centers!(X::AbstractMatrix{<:Real}, # in: sample matrix (p x n)
 end
 
 
-####
-#### Re-pick centers that get no samples assigned to them.
-####
-
+#
+#  Re-picks centers that get no samples assigned to them.
+#
 function repick_unused_centers(X::AbstractMatrix{<:Real},  # in: the sample set (p x n)
                                costs::Vector{<:Real},      # in: the current assignment costs (n)
                                centers::AbstractMatrix{<:AbstractFloat}, # out: the centers (p x k)

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -49,7 +49,7 @@ function kmeans!(X::AbstractMatrix{TX},                    # in: sample matrix (
     TC2 = promote_type(TX, TC)
     weights === nothing || (TC2 = promote_type(TC2, TW))
     # corner case where that's still not an AbstractFloat
-    TC2 = ifelse(TC2 <: AbstractFloat, TC2, Float64)
+    TC2 = float(TC2)
 
     _kmeans!(X, weights, convert(Matrix{TC2}, centers),
              assignments, counts, round(Int, maxiter), tol,

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -23,7 +23,7 @@ const _kmeans_default_tol = 1.0e-6
 const _kmeans_default_display = :none
 
 """
-    kmeans!(centers, X)
+    kmeans!(X, centers)
 
 Update the current centers `centers` (of size `d x k` where `d` is the dimension and `k` the
 number of centroids) using the samples contained in `X` (of size `d x n` where `n` is the number
@@ -101,9 +101,10 @@ function _kmeans!(X::AbstractMatrix{<:Real},                # in: sample matrix 
 
     # compute pairwise distances, preassign costs and cluster weights
     dmat = pairwise(distance, centers, X)
-    costs = Vector{eltype(dmat)}(undef, n)
     WC = (weights === nothing) ? Int : eltype(weights)
     cweights = Vector{WC}(undef, k)
+    D = typeof(one(eltype(dmat)) * one(WC))
+    costs = Vector{D}(undef, n)
 
     update_assignments!(dmat, true, assignments, costs, counts,
                         to_update, unused)
@@ -176,14 +177,14 @@ end
 #  Updates assignments, costs, and counts based on
 #  an updated (squared) distance matrix
 #
-function update_assignments!(dmat::Matrix{T},          # in:  distance matrix (k x n)
+function update_assignments!(dmat::Matrix{<:Real},     # in:  distance matrix (k x n)
                              is_init::Bool,            # in:  whether it is the initial run
                              assignments::Vector{Int}, # out: assignment vector (n)
-                             costs::Vector{T},         # out: costs of the resultant assignment (n)
+                             costs::Vector{<:Real},    # out: costs of the resultant assignment (n)
                              counts::Vector{Int},      # out: # samples assigned to each cluster (k)
                              to_update::Vector{Bool},  # out: whether a center needs update (k)
                              unused::Vector{Int}       # out: list of centers with no samples
-                             ) where T<:Real
+                             )
     k, n = size(dmat)
 
     # re-initialize the counting vector

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -150,7 +150,7 @@ function _kmeans!(X::AbstractMatrix{<:Real},                # in: sample matrix 
         objv_change = objv - prev_objv
 
         if objv_change > tol
-            @warn("The objective value changes towards an opposite direction")
+            @warn("The clustering cost increased at iteration #$t")
         elseif abs(objv_change) < tol
             converged = true
         end

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -6,8 +6,8 @@
 # D is the type of pairwise distance computation from samples to centers
 # WC is the type of cluster weights, either Int (in the case where samples are
 # unweighted) or eltype(weights) (in the case where samples are weighted).
-struct KmeansResult{T<:AbstractFloat,D<:Real,WC<:Real} <: ClusteringResult
-    centers::AbstractMatrix{T} # cluster centers (d x k)
+struct KmeansResult{C<:AbstractMatrix{<:AbstractFloat},D<:Real,WC<:Real} <: ClusteringResult
+    centers::C                 # cluster centers (d x k)
     assignments::Vector{Int}   # assignments (n)
     costs::Vector{D}           # cost of the assignments (n)
     counts::Vector{Int}        # number of samples assigned to each cluster (k)

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -153,8 +153,8 @@ function _kmeans!(X::AbstractMatrix{T},
         else
             # if only a small subset is affected, only compute for that subset
             affected_inds = findall(to_update)
-            dmat_p = pairwise(distance, view(centers, :, affected_inds), X)
-            dmat[affected_inds, :] .= dmat_p
+            pairwise!(view(dmat, affected_inds, :), distance,
+                      view(centers, :, affected_inds), X)
         end
 
         # update assignments

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -70,8 +70,8 @@ function kmeans(X::AbstractMatrix{<:Real},                # in: sample matrix (p
                 k::Integer;                               # in: number of centers
                 weights::Union{Nothing, AbstractVector{<:Real}}=nothing, # in: sample weights (n)
                 init::Symbol=_kmeans_default_init,        # in: initialization algorithm
-                maxiter::Int=_kmeans_default_maxiter,     # in: maximum number of iterations
-                tol::Float64=_kmeans_default_tol,         # in: tolerance  of change at convergence
+                maxiter::Integer=_kmeans_default_maxiter, # in: maximum number of iterations
+                tol::Real=_kmeans_default_tol,            # in: tolerance  of change at convergence
                 display::Symbol=_kmeans_default_display,  # in: level of display
                 distance::SemiMetric=SqEuclidean())       # in: function to calculate distance with
     p, n = size(X)
@@ -85,7 +85,7 @@ function kmeans(X::AbstractMatrix{<:Real},                # in: sample matrix (p
     centers = copyseeds!(Matrix{T}(undef, p, k), X, iseeds)
 
     kmeans!(centers, X;
-            weights=weights, maxiter=round(Int, maxiter), tol=tol,
+            weights=weights, maxiter=Int(maxiter), tol=Float64(tol),
             display=display, distance=distance)
 end
 
@@ -98,7 +98,7 @@ function _kmeans!(X::AbstractMatrix{<:Real},                # in: sample matrix 
                   assignments::Vector{Int},                 # out: vector of assignments (n)
                   counts::Vector{Int},                      # out: number of samples assigned to each cluster (k)
                   maxiter::Int,                             # in: maximum number of iterations
-                  tol::Real,                                # in: tolerance of change at convergence
+                  tol::Float64,                             # in: tolerance of change at convergence
                   displevel::Int,                           # in: the level of display
                   distance::SemiMetric)                     # in: function to calculate the distance with
     p, n = size(X)

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -65,7 +65,6 @@ function kmeans(X::AbstractMatrix{<:Real},                # in: sample matrix (d
                 display::Symbol=_kmeans_default_display,  # in: level of display
                 distance::SemiMetric=SqEuclidean())       # in: function to calculate distance with
     d, n = size(X)
-    k = round(Int, k)
     (2 <= k < n) || throw(ArgumentError("k must be 2 <= k < n, k=$k given."))
 
     # initialize the centers using a type wide enough so that the updates

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -2,7 +2,7 @@
 
 #### Interface
 
-# T is the eltype(centers)
+# C is the type of centers, an (abstract) matrix of size (d x k)
 # D is the type of pairwise distance computation from samples to centers
 # WC is the type of cluster weights, either Int (in the case where samples are
 # unweighted) or eltype(weights) (in the case where samples are weighted).

--- a/src/seeding.jl
+++ b/src/seeding.jl
@@ -44,7 +44,7 @@ function copyseeds!(S::Matrix{<:AbstractFloat}, X::AbstractMatrix{<:Real},
                     iseeds::AbstractVector)
     d, n = size(X)
     k = length(iseeds)
-    size(S) == (d, k) || throw(DimensionMismatch("Inconsistent array " *
+    size(S) == (d, k) || throw(DimensionMismatch("Inconsistent array dimensions."))
                                                  " dimensions."))
     for j = 1:k
         copyto!(view(S, :, j), view(X, :, iseeds[j]))

--- a/src/seeding.jl
+++ b/src/seeding.jl
@@ -54,7 +54,7 @@ end
 
 # NOTE: this should eventually be removed as only `copyseeds!` is used in `kmeans`.
 copyseeds(X::AbstractMatrix{<:Real}, iseeds::AbstractVector) =
-    copyseeds!(similar(X, size(X, 1), length(iseeds)), X, iseeds)
+    copyseeds!(Matrix{eltype(X)}(undef, size(X, 1), length(iseeds)), X, iseeds)
 
 function check_seeding_args(n::Integer, k::Integer)
     k >= 1 || error("The number of seeds must be positive.")

--- a/src/seeding.jl
+++ b/src/seeding.jl
@@ -40,8 +40,8 @@ initseeds_by_costs(algname::Symbol, costs::AbstractMatrix{<:Real}, k::Integer) =
 initseeds(iseeds::Vector{Int}, X::AbstractMatrix{<:Real}, k::Integer) = iseeds
 initseeds_by_costs(iseeds::Vector{Int}, costs::AbstractMatrix{<:Real}, k::Integer) = iseeds
 
-function copyseeds!(S::Matrix{TS}, X::AbstractMatrix{TX},
-                    iseeds::AbstractVector) where {TS<:AbstractFloat, TX<:Real}
+function copyseeds!(S::Matrix{<:AbstractFloat}, X::AbstractMatrix{<:Real},
+                    iseeds::AbstractVector)
     d, n = size(X)
     k = length(iseeds)
     size(S) == (d, k) || throw(DimensionMismatch("Inconsistent array " *
@@ -52,6 +52,7 @@ function copyseeds!(S::Matrix{TS}, X::AbstractMatrix{TX},
     return S
 end
 
+# NOTE: this should eventually be removed as only `copyseeds!` is used in `kmeans`.
 copyseeds(X::AbstractMatrix{<:Real}, iseeds::AbstractVector) =
     copyseeds!(Matrix{eltype(X)}(undef, size(X, 1), length(iseeds)), X, iseeds)
 

--- a/src/seeding.jl
+++ b/src/seeding.jl
@@ -52,7 +52,7 @@ function copyseeds!(S::Matrix{TS}, X::AbstractMatrix{TX},
     return S
 end
 
-copyseeds(X::AbstractMatrix{<:Real}, iseeds::AbstractVector, T::DataType) =
+copyseeds(X::AbstractMatrix{<:Real}, iseeds::AbstractVector, T::DataType=eltype(X)) =
     copyseeds!(Matrix{T}(undef, size(X, 1), length(iseeds)), X, iseeds)
 
 function check_seeding_args(n::Integer, k::Integer)

--- a/src/seeding.jl
+++ b/src/seeding.jl
@@ -52,8 +52,8 @@ function copyseeds!(S::Matrix{TS}, X::AbstractMatrix{TX},
     return S
 end
 
-copyseeds(X::AbstractMatrix{<:Real}, iseeds::AbstractVector, T::DataType=eltype(X)) =
-    copyseeds!(Matrix{T}(undef, size(X, 1), length(iseeds)), X, iseeds)
+copyseeds(X::AbstractMatrix{<:Real}, iseeds::AbstractVector) =
+    copyseeds!(Matrix{eltype(X)}(undef, size(X, 1), length(iseeds)), X, iseeds)
 
 function check_seeding_args(n::Integer, k::Integer)
     k >= 1 || error("The number of seeds must be positive.")

--- a/src/seeding.jl
+++ b/src/seeding.jl
@@ -40,22 +40,20 @@ initseeds_by_costs(algname::Symbol, costs::AbstractMatrix{<:Real}, k::Integer) =
 initseeds(iseeds::Vector{Int}, X::AbstractMatrix{<:Real}, k::Integer) = iseeds
 initseeds_by_costs(iseeds::Vector{Int}, costs::AbstractMatrix{<:Real}, k::Integer) = iseeds
 
-function copyseeds!(S::AbstractMatrix{T}, X::AbstractMatrix{T},
-                    iseeds::AbstractVector) where T<:Real
-    d = size(X, 1)
-    n = size(X, 2)
+function copyseeds!(S::Matrix{TS}, X::AbstractMatrix{TX},
+                    iseeds::AbstractVector) where {TS<:AbstractFloat, TX<:Real}
+    d, n = size(X)
     k = length(iseeds)
-    (size(X,1) == d && size(S) == (d, k)) ||
-        throw(DimensionMismatch("Inconsistent array dimensions."))
-
+    size(S) == (d, k) || throw(DimensionMismatch("Inconsistent array " *
+                                                 " dimensions."))
     for j = 1:k
-        copyto!(view(S,:,j), view(X,:,iseeds[j]))
+        copyto!(view(S, :, j), view(X, :, iseeds[j]))
     end
     return S
 end
 
-copyseeds(X::AbstractMatrix{<:Real}, iseeds::AbstractVector) =
-    copyseeds!(similar(X, size(X, 1), length(iseeds)), X, iseeds)
+copyseeds(X::AbstractMatrix{<:Real}, iseeds::AbstractVector, T::DataType) =
+    copyseeds!(Matrix{T}(undef, size(X, 1), length(iseeds)), X, iseeds)
 
 function check_seeding_args(n::Integer, k::Integer)
     k >= 1 || error("The number of seeds must be positive.")
@@ -68,7 +66,7 @@ end
 #   choose an arbitrary subset as seeds
 #
 
-mutable struct RandSeedAlg <: SeedingAlgorithm end
+struct RandSeedAlg <: SeedingAlgorithm end
 
 initseeds!(iseeds::IntegerVector, alg::RandSeedAlg, X::AbstractMatrix{<:Real}) = sample!(1:size(X, 2), iseeds; replace=false)
 
@@ -82,7 +80,7 @@ initseeds_by_costs!(iseeds::IntegerVector, alg::RandSeedAlg, X::AbstractMatrix{<
 #   18th Annual ACM-SIAM symposium on Discrete algorithms, 2007.
 #
 
-mutable struct KmppAlg <: SeedingAlgorithm end
+struct KmppAlg <: SeedingAlgorithm end
 
 function initseeds!(iseeds::IntegerVector, alg::KmppAlg,
                     X::AbstractMatrix{<:Real}, metric::PreMetric)
@@ -157,7 +155,7 @@ kmpp_by_costs(costs::AbstractMatrix{<:Real}, k::Int) = initseeds(KmppAlg(), cost
 #   doi:10.1016/j.eswa.2008.01.039
 #
 
-mutable struct KmCentralityAlg <: SeedingAlgorithm end
+struct KmCentralityAlg <: SeedingAlgorithm end
 
 function initseeds_by_costs!(iseeds::IntegerVector, alg::KmCentralityAlg,
                              costs::AbstractMatrix{<:Real})

--- a/src/seeding.jl
+++ b/src/seeding.jl
@@ -45,7 +45,6 @@ function copyseeds!(S::Matrix{<:AbstractFloat}, X::AbstractMatrix{<:Real},
     d, n = size(X)
     k = length(iseeds)
     size(S) == (d, k) || throw(DimensionMismatch("Inconsistent array dimensions."))
-                                                 " dimensions."))
     for j = 1:k
         copyto!(view(S, :, j), view(X, :, iseeds[j]))
     end

--- a/src/seeding.jl
+++ b/src/seeding.jl
@@ -54,7 +54,7 @@ end
 
 # NOTE: this should eventually be removed as only `copyseeds!` is used in `kmeans`.
 copyseeds(X::AbstractMatrix{<:Real}, iseeds::AbstractVector) =
-    copyseeds!(Matrix{eltype(X)}(undef, size(X, 1), length(iseeds)), X, iseeds)
+    copyseeds!(similar(X, size(X, 1), length(iseeds)), X, iseeds)
 
 function check_seeding_args(n::Integer, k::Integer)
     k >= 1 || error("The number of seeds must be positive.")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,15 +11,6 @@ counts(R::ClusteringResult) = R.counts
 assignments(R::ClusteringResult) = R.assignments
 
 
-##### convert weight options
-
-conv_weights(::Type{T}, n::Int, w::Nothing) where {T} = nothing
-
-function conv_weights(::Type{T}, n::Int, w::Vector) where T
-    length(w) == n || throw(DimensionMismatch("Incorrect length of weights."))
-    convert(Vector{T}, w)::Vector{T}
-end
-
 ##### convert display symbol to disp level
 
 display_level(s::Symbol) =

--- a/test/kmeans.jl
+++ b/test/kmeans.jl
@@ -114,4 +114,15 @@ end
     @test equal_kmresults(r, r_t)
 end
 
+x_int = rand(Int16, m, n)
+
+@testset "Integer data" begin
+    Random.seed!(654)
+    r = kmeans(x_int, k; maxiter=50)
+    Random.seed!(654)
+    r2 = kmeans(convert(Matrix{Float64}, x_int), k; maxiter=50)
+
+    @test equal_kmresults(r, r2)
+end
+
 end

--- a/test/kmeans.jl
+++ b/test/kmeans.jl
@@ -114,13 +114,31 @@ end
     @test equal_kmresults(r, r_t)
 end
 
-x_int = rand(Int16, m, n)
-
 @testset "Integer data" begin
+    x = rand(Int16, m, n)
     Random.seed!(654)
-    r = kmeans(x_int, k; maxiter=50)
+    r = kmeans(x, k; maxiter=50)
 
     @test isa(r, KmeansResult{Float64, Float64, Int})
 end
 
+@testset "kmeans! data types" begin
+    Random.seed!(1101)
+    for TX in (Int, Float32, Float64)
+        for TC in (Float32, Float64)
+            for TW in (Nothing, Int, Float32, Float64)
+                x = rand(TX, m, n)
+                c = rand(TC, m, k)
+                if TW == Nothing
+                    r = kmeans!(x, c; maxiter=1)
+                    @test isa(r, KmeansResult{TC,<:Real,Int})
+                else
+                    w = rand(TW, n)
+                    r = kmeans!(x, c; weights=w, maxiter=1)
+                    @test isa(r, KmeansResult{TC,<:Real,TW})
+                end
+            end
+        end
+    end
+end
 end

--- a/test/kmeans.jl
+++ b/test/kmeans.jl
@@ -35,7 +35,7 @@ equal_kmresults(km1::KmeansResult, km2::KmeansResult) =
 @testset "non-weighted" begin
     Random.seed!(34568)
     r = kmeans(x, k; maxiter=50)
-    @test isa(r, KmeansResult{Float64, Float64, Int})
+    @test isa(r, KmeansResult{Matrix{Float64}, Float64, Int})
     @test size(r.centers) == (m, k)
     @test length(r.assignments) == n
     @test all(a -> 1 <= a <= k, r.assignments)
@@ -55,7 +55,7 @@ end
     x32 = map(Float32, x)
     x32t = copy(x32')
     r = kmeans(x32, k; maxiter=50)
-    @test isa(r, KmeansResult{Float32, Float32, Int})
+    @test isa(r, KmeansResult{Matrix{Float32}, Float32, Int})
     @test size(r.centers) == (m, k)
     @test length(r.assignments) == n
     @test all(a -> 1 <= a <= k, r.assignments)
@@ -74,7 +74,7 @@ end
     w = rand(n)
     Random.seed!(34568)
     r = kmeans(x, k; maxiter=50, weights=w)
-    @test isa(r, KmeansResult{Float64, Float64, Float64})
+    @test isa(r, KmeansResult{Matrix{Float64}, Float64, Float64})
     @test size(r.centers) == (m, k)
     @test length(r.assignments) == n
     @test all(a -> 1 <= a <= k, r.assignments)
@@ -98,7 +98,7 @@ end
     Random.seed!(34568)
     r = kmeans(x, k; maxiter=50, init=:kmcen, distance=MySqEuclidean())
     r2 = kmeans(x, k; maxiter=50, init=:kmcen)
-    @test isa(r, KmeansResult{Float64, Float64, Int})
+    @test isa(r, KmeansResult{Matrix{Float64}, Float64, Int})
     @test size(r.centers) == (m, k)
     @test length(r.assignments) == n
     @test all(a -> 1 <= a <= k, r.assignments)
@@ -119,7 +119,7 @@ end
     Random.seed!(654)
     r = kmeans(x, k; maxiter=50)
 
-    @test isa(r, KmeansResult{Float64, Float64, Int})
+    @test isa(r, KmeansResult{Matrix{Float64}, Float64, Int})
 end
 
 @testset "kmeans! data types" begin
@@ -131,11 +131,11 @@ end
                 c = rand(TC, m, k)
                 if TW == Nothing
                     r = kmeans!(x, c; maxiter=1)
-                    @test isa(r, KmeansResult{TC,<:Real,Int})
+                    @test isa(r, KmeansResult{Matrix{TC},<:Real,Int})
                 else
                     w = rand(TW, n)
                     r = kmeans!(x, c; weights=w, maxiter=1)
-                    @test isa(r, KmeansResult{TC,<:Real,TW})
+                    @test isa(r, KmeansResult{Matrix{TC},<:Real,TW})
                 end
             end
         end

--- a/test/kmeans.jl
+++ b/test/kmeans.jl
@@ -11,7 +11,8 @@ struct MySqEuclidean <: SemiMetric end
 
 # redefinition of Distances.pairwise! for MySqEuclidean type
 function pairwise!(r::AbstractMatrix, dist::MySqEuclidean,
-                   a::AbstractMatrix, b::AbstractMatrix)
+                   a::AbstractMatrix, b::AbstractMatrix; dims::Integer=2)
+    dims == 2 || throw(ArgumentError("only dims=2 supported for MySqEuclidean distance"))
     mul!(r, transpose(a), b)
     sa2 = sum(abs2, a, dims=1)
     sb2 = sum(abs2, b, dims=1)

--- a/test/kmeans.jl
+++ b/test/kmeans.jl
@@ -7,7 +7,7 @@ using LinearAlgebra
 import Distances.pairwise!
 
 # custom distance metric
-mutable struct MySqEuclidean <: SemiMetric end
+struct MySqEuclidean <: SemiMetric end
 
 # redefinition of Distances.pairwise! for MySqEuclidean type
 function pairwise!(r::AbstractMatrix, dist::MySqEuclidean,
@@ -35,7 +35,7 @@ equal_kmresults(km1::KmeansResult, km2::KmeansResult) =
 @testset "non-weighted" begin
     Random.seed!(34568)
     r = kmeans(x, k; maxiter=50)
-    @test isa(r, KmeansResult{Float64})
+    @test isa(r, KmeansResult{Float64, Float64, Int})
     @test size(r.centers) == (m, k)
     @test length(r.assignments) == n
     @test all(a -> 1 <= a <= k, r.assignments)
@@ -55,7 +55,7 @@ end
     x32 = map(Float32, x)
     x32t = copy(x32')
     r = kmeans(x32, k; maxiter=50)
-    @test isa(r, KmeansResult{Float32})
+    @test isa(r, KmeansResult{Float32, Float32, Int})
     @test size(r.centers) == (m, k)
     @test length(r.assignments) == n
     @test all(a -> 1 <= a <= k, r.assignments)
@@ -74,7 +74,7 @@ end
     w = rand(n)
     Random.seed!(34568)
     r = kmeans(x, k; maxiter=50, weights=w)
-    @test isa(r, KmeansResult{Float64})
+    @test isa(r, KmeansResult{Float64, Float64, Float64})
     @test size(r.centers) == (m, k)
     @test length(r.assignments) == n
     @test all(a -> 1 <= a <= k, r.assignments)
@@ -98,7 +98,7 @@ end
     Random.seed!(34568)
     r = kmeans(x, k; maxiter=50, init=:kmcen, distance=MySqEuclidean())
     r2 = kmeans(x, k; maxiter=50, init=:kmcen)
-    @test isa(r, KmeansResult{Float64})
+    @test isa(r, KmeansResult{Float64, Float64, Int})
     @test size(r.centers) == (m, k)
     @test length(r.assignments) == n
     @test all(a -> 1 <= a <= k, r.assignments)
@@ -119,10 +119,8 @@ x_int = rand(Int16, m, n)
 @testset "Integer data" begin
     Random.seed!(654)
     r = kmeans(x_int, k; maxiter=50)
-    Random.seed!(654)
-    r2 = kmeans(convert(Matrix{Float64}, x_int), k; maxiter=50)
 
-    @test equal_kmresults(r, r2)
+    @test isa(r, KmeansResult{Float64, Float64, Int})
 end
 
 end


### PR DESCRIPTION
With apologies for being back so soon... 

This applies the following changes

"**major**"
1. `x_int = rand(Int16, 10, 20); kmeans(x_int, 3)` ~~is now processed by converting `x_int`  into `Float64` (i.e. something sensible is returned instead of an error)~~ now works by making sure the centers are of an appropriately wide type see #140 for which a similar solution could be applied. Test added for that case.
2. types are now checked for consistency. Effectively at the entry points, the types for `X`, `centers` and `weights` can be whatever the user wants ~~but `_kmeans!` is effectively called on one single type which is `eltype(X)`. Since this happens after conversion, we're sure the result is a floating point number of some type `T` and all operations, distances and updates are done in this type `T`.~~

"**minor**"
- following comments from #138, the style is unified somewhat with identation etc. 
- broadcasting with views is still not applied (I tried a number of ways, all were slower and allocated more) but some simplifications are applied (e.g. the bound check for `1<=assignment<=k` is always verified + in-place computations where appropriate.

I've added comments preceded by "NOTE REFACT:" to justify some of the changes hoping that would help with the reviews, these would be eventually removed of course.

**Mini benchmark**

(same as for #138)

**before**
```julia
julia> using BenchmarkTools, Random, Clustering; Random.seed!(1641); X = randn(500, 5000); w = abs.(randn(5000)); @btime kmeans($X, 3); @btime kmeans($X, 3, weights=w);
  137.222 ms (278 allocations: 1.63 MiB)
  95.003 ms (184 allocations: 1.13 MiB)
```

**after** (992c8bb)
```julia
julia> using BenchmarkTools, Random, Clustering; Random.seed!(1641); X = randn(500, 5000); w = abs.(randn(5000)); @btime kmeans($X, 3); @btime kmeans($X, 3, weights=w);
  106.599 ms (230 allocations: 1.32 MiB)
  83.018 ms (180 allocations: 1.05 MiB)
```