### PR TITLE
Fix doc build for Sphinx 1.4+

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,8 +31,15 @@ import os
 extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.pngmath',
 ]
+
+# use imgmath for Sphinx 1.4+, pngmath otherwise
+import sphinx
+from distutils.version import LooseVersion
+if LooseVersion(sphinx.__version__) < LooseVersion('1.4'):
+    extensions.append('sphinx.ext.pngmath')
+else:
+    extensions.append('sphinx.ext.imgmath')
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
More recent Sphinx versions (1.4+) use imgmath instead of pngmath.