### PR TITLE
Specialize MCL functions for Sparse Matrices

### DIFF
--- a/src/mcl.jl
+++ b/src/mcl.jl
@@ -5,7 +5,7 @@
 
 Result returned by `mcl()`.
 """
-struct MCLResult 
+struct MCLResult <: ClusteringResult
     mcl_adj::AbstractMatrix     # final MCL adjacency matrix (equilibrium state matrix if converged)
     assignments::Vector{Int}    # element-to-cluster assignments (n)
     counts::Vector{Int}         # number of samples assigned to each cluster (k)

--- a/src/mcl.jl
+++ b/src/mcl.jl
@@ -97,7 +97,7 @@ function _mcl_inflate(src::AbstractMatrix, inflation::Number)
     dest
 end
 
-function _mcl_inflate(dest::SparseMatrixCSC, src::SparseMatrixCSC, inflation::Number)
+function _mcl_inflate(src::SparseMatrixCSC, inflation::Number)
     dest = similar(src)
     @inbounds for i in 1:length(src.nzval)
         dest.nzval[i] = _mcl_el_inflate(src.nzval[i], inflation)

--- a/test/mcl.jl
+++ b/test/mcl.jl
@@ -71,13 +71,14 @@ end
 end
 
 @testset "sparse input matrix" begin
+    adj = sparse(adj_matrix)
     res = mcl(sparse(adj_matrix), display=:none, expansion=2)
     @test isa(res, MCLResult)
     @test length(res.assignments) == length(nodes)
     @test res.nunassigned == 0
     @test eltype(res.mcl_adj) === Float64
     res_dense = mcl(adj_matrix, display=:none, expansion=2)
-    @test Matrix(res.mcl_adj) == res_dense.assignments
+    @test Matrix(res.mcl_adj) == res_dense.mcl_adj
     @test res.assignments == res_dense.assignments
     @test res.counts == res_dense.counts
     @test res.rel_Δ ≈ res_dense.rel_Δ

--- a/test/mcl.jl
+++ b/test/mcl.jl
@@ -76,7 +76,14 @@ end
     @test length(res.assignments) == length(nodes)
     @test res.nunassigned == 0
     @test eltype(res.mcl_adj) === Float64
-
+    res_dense = mcl(adj_matrix, display=:none, expansion=2)
+    @test Matrix(res.mcl_adj) == res_dense.assignments
+    @test res.assignments == res_dense.assignments
+    @test res.counts == res_dense.counts
+    @test res.rel_Δ ≈ res_dense.rel_Δ
+    @test res.converged == res_dense.converged
+    @test res.nunassigned == res_dense.nunassigned
+    @test res.iterations == res_dense.iterations
     # fractional powers not supported for sparse matrices
     @test_broken mcl(sparse(adj_matrix), display=:none, expansion=2.1)
 end


### PR DESCRIPTION
I've needed to add some specialized functions for Sparse Matrices in the mcl implementation  to make it feasible for use on larger Matrices.
Benchmarking the old vs the new using:
```
using SparseArrays
using Clustering
using BenchmarkTools
using Random
Random.seed!(1)
adj = sprand(1000, 1000, 0.1)
@benchmark mcl(adj)
```
Old:
```julia> @benchmark mcl(adj)
BenchmarkTools.Trial: 
  memory estimate:  251.94 MiB
  allocs estimate:  103199
  --------------
  minimum time:     54.339 s (0.35% GC)
  median time:      54.339 s (0.35% GC)
  mean time:        54.339 s (0.35% GC)
  maximum time:     54.339 s (0.35% GC)
  --------------
  samples:          1
  evals/sample:     1
```
New:
```
julia> @benchmark mcl(adj)
BenchmarkTools.Trial: 
  memory estimate:  48.41 MiB
  allocs estimate:  20675
  --------------
  minimum time:     144.370 ms (5.11% GC)
  median time:      228.582 ms (9.42% GC)
  mean time:        279.637 ms (16.85% GC)
  maximum time:     578.249 ms (26.47% GC)
  --------------
  samples:          18
  evals/sample:     1
```

Note that this is a contrived example, using a dense matrix of size (1000,1000) is faster. Using this only makes sense for larger sparse matrices which don't fit into memory.