### PR TITLE
Bump Julia to v1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
+  - 1.1
   - nightly
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # Clustering.jl
 
-This package provides a set of algorithms for data clustering.
-
-[![0.6](http://pkg.julialang.org/badges/Clustering_0.6.svg)](http://pkg.julialang.org/?pkg=Clustering&ver=0.6)
-[![0.7](http://pkg.julialang.org/badges/Clustering_0.7.svg)](http://pkg.julialang.org/?pkg=Clustering&ver=0.7)
-[![1.0](http://pkg.julialang.org/badges/Clustering_1.0.svg)](http://pkg.julialang.org/?pkg=Clustering&ver=1.0)
+Methods for data clustering and evaluation of clustering quality.
 
 [![Travis](https://travis-ci.org/JuliaStats/Clustering.jl.svg?branch=master)](https://travis-ci.org/JuliaStats/Clustering.jl)
 [![Coveralls](https://coveralls.io/repos/github/JuliaStats/Clustering.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaStats/Clustering.jl?branch=master)
@@ -15,7 +11,7 @@ This package provides a set of algorithms for data clustering.
 Pkg.add("Clustering")
 ```
 
-## Functionalities
+## Features
 
 ### Clustering Algorithms
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.7
+julia 1.0
 Distances 0.8.0
 NearestNeighbors 0.0.3
 StatsBase 0.9.0


### PR DESCRIPTION
I suppose we don't need to support v0.7 anymore. Instead, I've added v1.1 to CI.

I also removed the package badges as they do not work for v1.0+.

