### PR TITLE
Add links to other clustering-related pkgs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,9 @@ Pkg.add("Clustering")
 
 [docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
 [docs-stable-url]: http://JuliaStats.github.io/Clustering.jl/stable/
+
+## See Also
+
+Julia packages providing other clustering methods:
+ - [QuickShiftClustering.jl](https://github.com/rened/QuickShiftClustering.jl)
+ - [SpectralClustering.jl](https://github.com/lucianolorenti/SpectralClustering.jl)


### PR DESCRIPTION
Clustering.jl cannot and should not accommodate all existing clustering methods, but it's nice to inform the people about alternatives.
I'm not sure what should be the criteria for this list: should it be any packages tackling with the clustering problem or only high-quality actively maintained ones?
