### PR TITLE
Seeding: checks, tests, cleanups

### DIFF
--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -3,3 +3,6 @@
 # deprecated at 0.13
 @deprecate kmpp(X, k) initseeds(:kmpp, X, k)
 @deprecate kmpp_by_costs(costs, k) initseeds_by_costs(:kmpp, costs, k)
+
+# deprecated at 0.13.1
+@deprecate copyseeds(X, iseeds) copyseeds!(Matrix{eltype(X)}(undef, size(X, 1), length(iseeds)), X, iseeds)

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -72,7 +72,8 @@ is a ``d``-dimensional data point) into `k` clusters.
  - `init` (defaults to `:kmpp`): how cluster seeds should be initialized, could
    be one of the following:
    * a `Symbol`, the name of a seeding algorithm (see [Seeding](@ref) for a list
-     of supported methods).
+     of supported methods);
+   * an instance of [`SeedingAlgorithm`](@ref);
    * an integer vector of length ``k`` that provides the indices of points to
      use as initial seeds.
  - `weights`: ``n``-element vector of point weights (the cluster centers are
@@ -82,7 +83,8 @@ is a ``d``-dimensional data point) into `k` clusters.
 function kmeans(X::AbstractMatrix{<:Real},                # in: data matrix (d x n) columns = obs
                 k::Integer;                               # in: number of centers
                 weights::Union{Nothing, AbstractVector{<:Real}}=nothing, # in: data point weights (n)
-                init::Symbol=_kmeans_default_init,        # in: initialization algorithm
+                init::Union{Symbol, SeedingAlgorithm, AbstractVector{<:Integer}}=
+                        _kmeans_default_init,             # in: initialization algorithm
                 maxiter::Integer=_kmeans_default_maxiter, # in: maximum number of iterations
                 tol::Real=_kmeans_default_tol,            # in: tolerance  of change at convergence
                 display::Symbol=_kmeans_default_display,  # in: level of display

--- a/src/seeding.jl
+++ b/src/seeding.jl
@@ -141,7 +141,8 @@ proportional to the minimum cost of assigning it to the existing seeds.
 struct KmppAlg <: SeedingAlgorithm end
 
 function initseeds!(iseeds::IntegerVector, alg::KmppAlg,
-                    X::AbstractMatrix{<:Real}, metric::PreMetric)
+                    X::AbstractMatrix{<:Real},
+                    metric::PreMetric = SqEuclidean())
     n = size(X, 2)
     k = length(iseeds)
     check_seeding_args(n, k)
@@ -170,9 +171,6 @@ function initseeds!(iseeds::IntegerVector, alg::KmppAlg,
 
     return iseeds
 end
-
-initseeds!(iseeds::IntegerVector, alg::KmppAlg, X::AbstractMatrix{<:Real}) =
-    initseeds!(iseeds, alg, X, SqEuclidean())
 
 function initseeds_by_costs!(iseeds::IntegerVector, alg::KmppAlg,
                              costs::AbstractMatrix{<:Real})
@@ -243,8 +241,6 @@ function initseeds_by_costs!(iseeds::IntegerVector, alg::KmCentralityAlg,
     return iseeds
 end
 
-initseeds!(iseeds::IntegerVector, alg::KmCentralityAlg, X::AbstractMatrix{<:Real}, metric::PreMetric) =
+initseeds!(iseeds::IntegerVector, alg::KmCentralityAlg, X::AbstractMatrix{<:Real},
+           metric::PreMetric = SqEuclidean()) =
     initseeds_by_costs!(iseeds, alg, pairwise(metric, X, dims=2))
-
-initseeds!(iseeds::IntegerVector, alg::KmCentralityAlg, X::AbstractMatrix{<:Real}) =
-    initseeds!(iseeds, alg, X, SqEuclidean())

--- a/src/seeding.jl
+++ b/src/seeding.jl
@@ -244,8 +244,6 @@ function initseeds_by_costs!(iseeds::IntegerVector, alg::KmCentralityAlg,
 
     # scores[j] = \sum_j costs[i,j] / (\sum_{j'} costs[i,j'])
     #           = costs[i,j] * coefs[i]
-    #
-    # So this is matrix-vector multiplication
     scores = costs'coefs
 
     # lower score indicates better seeds

--- a/src/seeding.jl
+++ b/src/seeding.jl
@@ -77,8 +77,21 @@ initseeds(algname::Symbol, X::AbstractMatrix{<:Real}, k::Integer) =
 initseeds_by_costs(algname::Symbol, costs::AbstractMatrix{<:Real}, k::Integer) =
     initseeds_by_costs(seeding_algorithm(algname), costs, k)
 
-initseeds(iseeds::Vector{Int}, X::AbstractMatrix{<:Real}, k::Integer) = iseeds
-initseeds_by_costs(iseeds::Vector{Int}, costs::AbstractMatrix{<:Real}, k::Integer) = iseeds
+# use specified vector of seeds
+function initseeds(iseeds::AbstractVector{<:Integer}, X::AbstractMatrix{<:Real}, k::Integer)
+    length(iseeds) == k ||
+        throw(ArgumentError("The length of seeds vector ($(length(iseeds))) differs from the number of seeds requested ($k)"))
+    check_seeding_args(X, iseeds)
+    n = size(X, 2)
+    # check that seed indices are fine
+    for (i, seed) in enumerate(iseeds)
+        (1 <= seed <= n) || throw(ArgumentError("Seed #$i refers to an incorrect data point ($seed)"))
+    end
+    # NOTE no duplicate checks are done, should we?
+    convert(Vector{Int}, iseeds)
+end
+initseeds_by_costs(iseeds::AbstractVector{<:Integer}, costs::AbstractMatrix{<:Real}, k::Integer) =
+    initseeds(iseeds, costs, k) # NOTE: passing costs as X, but should be fine since only size(X, 2) is used
 
 function copyseeds!(S::Matrix{<:AbstractFloat}, X::AbstractMatrix{<:Real},
                     iseeds::AbstractVector)

--- a/src/seeding.jl
+++ b/src/seeding.jl
@@ -83,10 +83,6 @@ function copyseeds!(S::Matrix{<:AbstractFloat}, X::AbstractMatrix{<:Real},
     return S
 end
 
-# NOTE: this should eventually be removed as only `copyseeds!` is used in `kmeans`.
-copyseeds(X::AbstractMatrix{<:Real}, iseeds::AbstractVector) =
-    copyseeds!(Matrix{eltype(X)}(undef, size(X, 1), length(iseeds)), X, iseeds)
-
 function check_seeding_args(n::Integer, k::Integer)
     k >= 1 || error("The number of seeds must be positive.")
     k <= n || error("Attempted to select more seeds than data points.")
@@ -219,7 +215,7 @@ function initseeds_by_costs!(iseeds::IntegerVector, alg::KmCentralityAlg,
 
     n = size(costs, 1)
     k = length(iseeds)
-    k <= n || error("Attempted to select more seeds than points.")
+    check_seeding_args(n, k)
 
     # compute score for each item
     coefs = vec(sum(costs, dims=2))

--- a/src/seeding.jl
+++ b/src/seeding.jl
@@ -93,16 +93,14 @@ end
 initseeds_by_costs(iseeds::AbstractVector{<:Integer}, costs::AbstractMatrix{<:Real}, k::Integer) =
     initseeds(iseeds, costs, k) # NOTE: passing costs as X, but should be fine since only size(X, 2) is used
 
-function copyseeds!(S::Matrix{<:AbstractFloat}, X::AbstractMatrix{<:Real},
+function copyseeds!(S::AbstractMatrix{<:AbstractFloat},
+                    X::AbstractMatrix{<:Real},
                     iseeds::AbstractVector)
     d, n = size(X)
     k = length(iseeds)
     size(S) == (d, k) ||
         throw(DimensionMismatch("Inconsistent seeds matrix dimensions: $((d, k)) expected, $(size(S)) given."))
-    for j = 1:k
-        copyto!(view(S, :, j), view(X, :, iseeds[j]))
-    end
-    return S
+    return copyto!(S, view(X, :, iseeds))
 end
 
 """

--- a/test/kmeans.jl
+++ b/test/kmeans.jl
@@ -54,7 +54,7 @@ equal_kmresults(km1::KmeansResult, km2::KmeansResult) =
     @test length(r.costs) == n
     @test length(r.counts) == k
     @test sum(r.counts) == n
-    @test r.cweights == map(Float64, r.counts)
+    @test r.cweights == r.counts
     @test sum(r.costs) ≈ r.totalcost
 
     Random.seed!(34568)
@@ -74,7 +74,7 @@ end
     @test length(r.costs) == n
     @test length(r.counts) == k
     @test sum(r.counts) == n
-    @test r.cweights == map(Float64, r.counts)
+    @test r.cweights == r.counts
     @test sum(r.costs) ≈ r.totalcost
 
     Random.seed!(34568)
@@ -117,7 +117,7 @@ end
     @test length(r.costs) == n
     @test length(r.counts) == k
     @test sum(r.counts) == n
-    @test r.cweights == map(Float64, r.counts)
+    @test r.cweights == r.counts
     @test sum(r.costs) ≈ r.totalcost
     @test equal_kmresults(r, r2)
 

--- a/test/kmeans.jl
+++ b/test/kmeans.jl
@@ -173,4 +173,5 @@ end
         end
     end
 end
+
 end

--- a/test/kmeans.jl
+++ b/test/kmeans.jl
@@ -126,6 +126,26 @@ end
     @test equal_kmresults(r, r_t)
 end
 
+@testset "Argument checks" begin
+    Random.seed!(34568)
+    n = 50
+    k = 10
+    x = randn(m, n)
+
+    @testset "init=" begin
+        @test_throws ArgumentError kmeans(x, k, init=1:(k-2))
+        @test_throws ArgumentError kmeans(x, k, init=1:(k+2))
+        @test kmeans(x, k, init=1:k, maxiter=5) isa KmeansResult
+
+        @test_throws ArgumentError kmeans(x, k, init=:myseeding)
+        for algname in (:kmpp, :kmcen, :rand)
+            alg = Clustering.seeding_algorithm(algname)
+            @test kmeans(x, k, init=algname) isa KmeansResult
+            @test kmeans(x, k, init=alg) isa KmeansResult
+        end
+    end
+end
+
 @testset "Integer data" begin
     x = rand(Int16, m, n)
     Random.seed!(654)

--- a/test/seeding.jl
+++ b/test/seeding.jl
@@ -36,6 +36,24 @@ Ct = copy(transpose(C))
 
 md0 = min_interdist(X)
 
+@testset "Argument checks" begin
+    @test_throws ArgumentError initseeds(:myseeding, X, 2)
+    iseeds = initseeds(:kmpp, X, k)
+    @test_throws DimensionMismatch copyseeds!(Matrix{Float64}(undef, 3, 6), X, iseeds)
+    @test_throws DimensionMismatch copyseeds!(Matrix{Float64}(undef, 4, 5), X, iseeds)
+    @test copyseeds!(Matrix{Float64}(undef, 3, 5), X, iseeds) isa Matrix{Float64}
+
+    @testset "Seeds number check for $(typeof(alg))" for alg in
+            (RandSeedAlg(), KmppAlg(), KmCentralityAlg())
+        @test_throws ArgumentError initseeds(alg, X, 0)
+        @test_throws ArgumentError initseeds(alg, X, n + 1)
+        @test_throws ArgumentError initseeds_by_costs(alg, C, 0)
+        @test_throws ArgumentError initseeds_by_costs(alg, C, n + 1)
+        @test initseeds(alg, X, 4) isa Vector{Int}
+        @test initseeds_by_costs(alg, C, 4) isa Vector{Int}
+    end
+end
+
 @testset "RandSeed" begin
     Random.seed!(34568)
     iseeds = initseeds(RandSeedAlg(), X, k)
@@ -44,6 +62,10 @@ md0 = min_interdist(X)
     Random.seed!(34568)
     iseeds_t = initseeds(RandSeedAlg(), Xt', k)
     @test iseeds == iseeds_t
+
+    Random.seed!(34568)
+    iseeds2 = initseeds(:rand, X, k)
+    @test iseeds2 == iseeds
 
     Random.seed!(34568)
     iseeds = initseeds_by_costs(RandSeedAlg(), C, k)
@@ -70,6 +92,13 @@ end
     @test iseeds == iseeds_t
 
     Random.seed!(34568)
+    iseeds2 = initseeds(:kmpp, X, k)
+    @test iseeds2 == iseeds
+    Random.seed!(34568)
+    iseeds_t2 = initseeds(:kmpp, Xt', k)
+    @test iseeds_t2 == iseeds_t
+
+    Random.seed!(34568)
     iseeds = initseeds_by_costs(KmppAlg(), C, k)
     @test length(iseeds) == k
     @test alldistinct(iseeds)
@@ -79,14 +108,6 @@ end
 
     @test min_interdist(X[:, iseeds]) > 20 * md0
     @test min_interdist((Xt')[:, iseeds]) > 20 * md0
-
-    Random.seed!(34568)
-    iseeds = initseeds(:kmpp, X, k)
-    @test length(iseeds) == k
-    @test alldistinct(iseeds)
-    Random.seed!(34568)
-    iseeds_t = initseeds(:kmpp, Xt', k)
-    @test iseeds_t == iseeds
 
     Random.seed!(34568)
     iseeds = initseeds_by_costs(:kmpp, C, k)
@@ -105,6 +126,13 @@ end
     Random.seed!(34568)
     iseeds_t = initseeds(KmCentralityAlg(), Xt', k)
     @test iseeds == iseeds_t
+
+    Random.seed!(34568)
+    iseeds2 = initseeds(:kmcen, X, k)
+    @test iseeds2 == iseeds
+    Random.seed!(34568)
+    iseeds_t2 = initseeds(:kmcen, Xt', k)
+    @test iseeds_t2 == iseeds_t
 
     Random.seed!(34568)
     iseeds = initseeds_by_costs(KmCentralityAlg(), C, k)

--- a/test/seeding.jl
+++ b/test/seeding.jl
@@ -53,10 +53,10 @@ md0 = min_interdist(X)
     iseeds_t = initseeds_by_costs(RandSeedAlg(), Ct', k)
     @test iseeds == iseeds_t
 
-    R = copyseeds(X, iseeds)
+    R = copyseeds!(Matrix{Float64}(undef, d, k), X, iseeds)
     @test isa(R, Matrix{Float64})
     @test R == X[:, iseeds]
-    R_t = copyseeds(Xt', iseeds)
+    R_t = copyseeds!(Matrix{Float64}(undef, d, k), Xt', iseeds)
     @test R == R_t
 end
 

--- a/test/seeding.jl
+++ b/test/seeding.jl
@@ -37,6 +37,14 @@ Ct = copy(transpose(C))
 md0 = min_interdist(X)
 
 @testset "Argument checks" begin
+    @test_throws ArgumentError initseeds([1, 2], X, 3)
+    @test initseeds([1, 2], X, 2) == [1, 2]
+    @test_throws ArgumentError initseeds([-1, 2, 3], X, 3)
+    @test_throws ArgumentError initseeds([1, n+2, 3], X, 3)
+
+    @test_throws ArgumentError initseeds_by_costs([1, 2], C, 3)
+    @test initseeds_by_costs([1, 2], C, 2) == [1, 2]
+
     @test_throws ArgumentError initseeds(:myseeding, X, 2)
     iseeds = initseeds(:kmpp, X, k)
     @test_throws DimensionMismatch copyseeds!(Matrix{Float64}(undef, 3, 6), X, iseeds)


### PR DESCRIPTION
* more checks and tests for the params of seeding functions
* deprecate `copyseeds()`
* restore support for `init::Vector{Int}` and `init::SeedingAlgorithm` in `kmeans()` (#162)
* small cleanups