### PR TITLE
Cleanup docs

### DIFF
--- a/doc/Project.toml
+++ b/doc/Project.toml
@@ -4,4 +4,4 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
 
 [compat]
-Documenter = "~0.21"
+Documenter = "~0.22"

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -6,7 +6,7 @@ makedocs(
     sitename = "Clustering.jl",
     modules = [Clustering],
     pages = [
-        "Clustering.jl Docs" => "index.md",
+        "Introduction" => "index.md",
         "Algorithms" => [
             "algorithms.md",
             "init.md",
@@ -26,7 +26,6 @@ makedocs(
             "vmeasure.md",
         ]
     ],
-    debug = false,
 )
 
 deploydocs(

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -1,10 +1,9 @@
 # Clustering.jl package
 
-*Clustering.jl* is a Julia package for data clustering. It covers three aspects
-related to data clustering:
+*Clustering.jl* is a Julia package for data clustering. It covers the two
+aspects of data clustering:
 
   - [Clustering Algorithms](@ref clu_algo_basics), *e.g.* K-means, K-medoids, Affinity
     propagation, and DBSCAN, etc.
-  - [Clustering Initialization](@ref clu_algo_init), *e.g.* K-means++ seeding.
   - [Clustering Evaluation](@ref clu_validate), *e.g.* Silhouettes and variational
     information.

--- a/doc/source/randindex.md
+++ b/doc/source/randindex.md
@@ -3,14 +3,7 @@
 [Rand index](http://en.wikipedia.org/wiki/Rand_index) is a measure of
 the similarity between the two data clusterings. From a mathematical
 standpoint, Rand index is related to the accuracy, but is applicable
-even when class labels are not used. The measure was introduced in
-
-> Lawrence Hubert and Phipps Arabie (1985). *Comparing partitions.*
-> Journal of Classification 2 (1): 193–218
-
-See also:
-> Meila, Marina (2003). *Comparing Clusterings by the Variation of
-> Information.* Learning Theory and Kernel Machines: 173–187.
+even when class labels are not used.
 
 ```@docs
 randindex

--- a/doc/source/silhouette.md
+++ b/doc/source/silhouette.md
@@ -3,11 +3,7 @@
 [Silhouettes](http://en.wikipedia.org/wiki/Silhouette_(clustering)) is
 a method for evaluating the quality of clustering. Particularly, it provides a
 quantitative way to measure how well each point lies within its cluster in
-comparison to the other clusters. It was introduced in
-
-> Peter J. Rousseeuw (1987). *Silhouettes: a Graphical Aid to the
-> Interpretation and Validation of Cluster Analysis*. Computational and
-> Applied Mathematics. 20: 53–65.
+comparison to the other clusters.
 
 The *Silhouette* value for the ``i``-th data point is:
 ```math

--- a/doc/source/varinfo.md
+++ b/doc/source/varinfo.md
@@ -4,10 +4,7 @@
 (also known as *shared information distance*) is a measure of the
 distance between the two clusterings. It is devised from the *mutual
 information*, but it is a true metric, *i.e.* it is symmetric and satisfies
-the triangle inequality. See
-
-> Meila, Marina (2003). *Comparing Clusterings by the Variation of
-> Information.* Learning Theory and Kernel Machines: 173–187.
+the triangle inequality.
 
 ```@docs
 varinfo

--- a/src/affprop.jl
+++ b/src/affprop.jl
@@ -9,7 +9,9 @@
 #### Interface
 
 """
-The result of affinity propagation clustering ([`affinityprop`](@ref)).
+    AffinityPropResult <: ClusteringResult
+
+The output of affinity propagation clustering ([`affinityprop`](@ref)).
 
 # Fields
  * `exemplars::Vector{Int}`: indices of *exemplars* (cluster centers)
@@ -32,7 +34,7 @@ const _afp_default_display = :none
 
 """
     affinityprop(S::DenseMatrix; [maxiter=200], [tol=1e-6], [damp=0.5],
-                 [display=:none])
+                 [display=:none]) -> AffinityPropResult
 
 Perform affinity propagation clustering based on a similarity matrix `S`.
 
@@ -40,17 +42,13 @@ Perform affinity propagation clustering based on a similarity matrix `S`.
 the ``i``-th and ``j``-th points, ``S_{ii}`` defines the *availability*
 of the ``i``-th point as an *exemplar*.
 
-Returns an instance of [`AffinityPropResult`](@ref).
-
-# Method parameters
+# Arguments
  - `damp::Real`: the dampening coefficient, ``0 ≤ \\mathrm{damp} < 1``.
    Larger values indicate slower (and probably more stable) update.
    ``\\mathrm{damp} = 0`` disables dampening.
  - `maxiter`, `tol`, `display`: see [common options](@ref common_options)
 
-# Notes
-The implementations is based on the following paper:
-
+# References
 > Brendan J. Frey and Delbert Dueck. *Clustering by Passing Messages
 > Between Data Points.* Science, vol 315, pages 972-976, 2007.
 """

--- a/src/fuzzycmeans.jl
+++ b/src/fuzzycmeans.jl
@@ -3,6 +3,8 @@
 ## Interface
 
 """
+    FuzzyCMeansResult{T<:AbstractFloat} <: ClusteringResult
+
 The output of [`fuzzy_cmeans`](@ref) function.
 
 # Fields
@@ -58,11 +60,10 @@ const _fcmeans_default_tol = 1.0e-3
 const _fcmeans_default_display = :none
 
 """
-    fuzzy_cmeans(data::AbstractMatrix, C::Int, fuzziness::Real; [...])
+    fuzzy_cmeans(data::AbstractMatrix, C::Int, fuzziness::Real,
+                 [...]) -> FuzzyCMeansResult
 
-Performs Fuzzy C-means clustering over the given `data`.
-
-Returns an instance of [`FuzzyCMeansResult`](@ref).
+Perform Fuzzy C-means clustering over the given `data`.
 
 # Arguments
  - `data::AbstractMatrix`: ``d×n`` data matrix. Each column represents
@@ -71,7 +72,7 @@ Returns an instance of [`FuzzyCMeansResult`](@ref).
  - `fuzziness::Real`: clusters fuzziness (see ``m`` in the
    [mathematical formulation](@ref fuzzy_cmeans_def)), ``\\mathrm{fuzziness} > 1``.
 
-One may also control the algorithm via the following optional keyword arguments:
+Optional keyword arguments:
  - `dist_metric::Metric` (defaults to `Euclidean`): the `Metric` object
     that defines the distance between the data points
  - `maxiter`, `tol`, `display`: see [common options](@ref common_options)

--- a/src/hclust.jl
+++ b/src/hclust.jl
@@ -4,6 +4,8 @@
 ## Algorithms are based upon C. F. Olson, Parallel Computing 21 (1995) 1313--1325.
 
 """
+    Hclust{T<:Real}
+
 The output of [`hclust`](@ref), hierarchical clustering of data points.
 
 Provides the bottom-up definition of the dendrogram as the sequence of
@@ -244,6 +246,8 @@ function hclust_n3(d::AbstractMatrix, linkage::Function)
 end
 
 """
+    ReducibleMetric{T<:Real}
+
 Base type for _reducible_ Lance–Williams cluster metrics.
 
 The metric `d` is called _reducible_ if for any clusters `A`, `B` and `C` and
@@ -262,6 +266,8 @@ formula that defines `d(A∪B, C)` using `d(A, C)`, `d(B, C)` and `d(A, B)`.
 abstract type ReducibleMetric{T <: Real} end
 
 """
+    MinimalDistance <: ReducibleMetric
+
 Distance between the clusters is the minimal distance between any pair of their
 points.
 """
@@ -278,6 +284,8 @@ end
     (d[k, i] > d_kj) && (d[k, i] = d_kj)
 
 """
+    WardDistance <: ReducibleMetric
+
 Ward distance between the two clusters `A` and `B` is the amount by
 which merging the two clusters into a single larger cluster `A∪B` would increase
 the average squared distance of a point to its cluster centroid.
@@ -297,6 +305,8 @@ end
 end
 
 """
+    AverageDistance <: ReducibleMetric
+
 Average distance between a pair of points from each clusters.
 """
 struct AverageDistance{T} <: ReducibleMetric{T}
@@ -314,7 +324,9 @@ end
 end
 
 """
-Maximum distance between a pair of point from each clusters.
+    MaximumDistance <: ReducibleMetric
+
+Maximum distance between a pair of points from each clusters.
 """
 struct MaximumDistance{T} <: ReducibleMetric{T}
     MaximumDistance(d::AbstractMatrix{T}) where T<:Real = new{T}()
@@ -625,12 +637,10 @@ function hclust_nn_lw(d::AbstractMatrix, metric::ReducibleMetric{T}) where {T<:R
 end
 
 """
-    hclust(d::AbstractMatrix; [linkage], [uplo])
+    hclust(d::AbstractMatrix; [linkage], [uplo]) -> Hclust
 
 Perform hierarchical clustering using the distance matrix `d` and
 the cluster `linkage` function.
-
-Returns the dendrogram as an object of type [`Hclust`](@ref).
 
 # Arguments
  - `d::AbstractMatrix`: the pairwise distance matrix. ``d_{ij}`` is the distance
@@ -685,9 +695,9 @@ end
 @deprecate hclust(d, method::Symbol, uplo::Union{Symbol, Nothing} = nothing) hclust(d, linkage=method, uplo=uplo)
 
 """
-    cutree(hclu::Hclust; [k], [h])
+    cutree(hclu::Hclust; [k], [h]) -> Vector{Int}
 
-Cuts the `hclu` dendrogram to produce clusters at the specified level of
+Cut the `hclu` dendrogram to produce clusters at the specified level of
 granularity.
 
 Returns the cluster assignments vector ``z`` (``z_i`` is the index of the

--- a/src/hclust.jl
+++ b/src/hclust.jl
@@ -642,6 +642,8 @@ end
 Perform hierarchical clustering using the distance matrix `d` and
 the cluster `linkage` function.
 
+Returns the dendrogram as a [`Hclust`](@ref) object.
+
 # Arguments
  - `d::AbstractMatrix`: the pairwise distance matrix. ``d_{ij}`` is the distance
     between ``i``-th and ``j``-th points.

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -7,9 +7,14 @@
 # WC is the type of cluster weights, either Int (in the case where points are
 # unweighted) or eltype(weights) (in the case where points are weighted).
 """
-The output of K-means algorithm.
+    KmeansResult{C,D<:Real,WC<:Real} <: ClusteringResult
 
-See also: [`kmeans`](@ref), [`kmeans!`](@ref).
+The output of [`kmeans`](@ref) and [`kmeans!`](@ref).
+
+# Type parameters
+ * `C<:AbstractMatrix{<:AbstractFloat}`: type of the `centers` matrix
+ * `D<:Real`: type of the assignment cost
+ * `WC<:Real`: type of the cluster weight
 """
 struct KmeansResult{C<:AbstractMatrix{<:AbstractFloat},D<:Real,WC<:Real} <: ClusteringResult
     centers::C                 # cluster centers (d x k)
@@ -28,13 +33,11 @@ const _kmeans_default_tol = 1.0e-6
 const _kmeans_default_display = :none
 
 """
-    kmeans!(X, centers; [kwargs...])
+    kmeans!(X, centers; [kwargs...]) -> KmeansResult
 
 Update the current cluster `centers` (``d×k`` matrix, where ``d`` is the
 dimension and ``k`` the number of centroids) using the ``d×n`` data
 matrix `X` (each column of `X` is a ``d``-dimensional data point).
-
-Returns `KmeansResult` object.
 
 See [`kmeans`](@ref) for the description of optional `kwargs`.
 """
@@ -60,14 +63,12 @@ end
 
 
 """
-    kmeans(X, k, [...])
+    kmeans(X, k, [...]) -> KmeansResult
 
 K-means clustering of the ``d×n`` data matrix `X` (each column of `X`
 is a ``d``-dimensional data point) into `k` clusters.
 
-Returns `KmeansResult` object.
-
-# Algorithm Options
+# Arguments
  - `init` (defaults to `:kmpp`): how cluster seeds should be initialized, could
    be one of the following:
    * a `Symbol`, the name of a seeding algorithm (see [Seeding](@ref) for a list

--- a/src/kmedoids.jl
+++ b/src/kmedoids.jl
@@ -42,8 +42,8 @@ const _kmed_default_display = :none
     kmedoids(costs::DenseMatrix, k::Integer; ...) -> KmedoidsResult
 
 Perform K-medoids clustering of ``n`` points into `k` clusters,
-given the `costs` matrix (``n×n``, ``\\mathrm{costs}_{ij}`` is the cost of
-assigning ``j``-th point to the mediod represented by the ``i``-th point).
+given the `costs` matrix (``n×n``, `costs[i, j]` is the cost of
+assigning `j`-th point to the medoid represented by the `i`-th point).
 
 # Note
 This package implements a K-means style algorithm instead of PAM, which
@@ -82,6 +82,9 @@ end
               [kwargs...]) -> KmedoidsResult
 
 Update the current cluster `medoids` using the `costs` matrix.
+
+The `medoids` field of the returned `KmedoidsResult` points to the same array
+as `medoids` argument.
 
 See [`kmedoids`](@ref) for the description of optional `kwargs`.
 """

--- a/src/kmedoids.jl
+++ b/src/kmedoids.jl
@@ -4,6 +4,8 @@
 #### Result type
 
 """
+    KmedoidsResult{T} <: ClusteringResult
+
 The output of [`kmedoids`](@ref) function.
 
 # Fields
@@ -37,19 +39,17 @@ const _kmed_default_tol = 1.0e-8
 const _kmed_default_display = :none
 
 """
-    kmedoids(costs::DenseMatrix, k::Integer; ...)
+    kmedoids(costs::DenseMatrix, k::Integer; ...) -> KmedoidsResult
 
-Performs K-medoids clustering of ``n`` points into `k` clusters,
+Perform K-medoids clustering of ``n`` points into `k` clusters,
 given the `costs` matrix (``n×n``, ``\\mathrm{costs}_{ij}`` is the cost of
 assigning ``j``-th point to the mediod represented by the ``i``-th point).
-
-Returns an object of type [`KmedoidsResult`](@ref).
 
 # Note
 This package implements a K-means style algorithm instead of PAM, which
 is considered much more efficient and reliable.
 
-# Algorithm Options
+# Arguments
  - `init` (defaults to `:kmpp`): how medoids should be initialized, could
    be one of the following:
    * a `Symbol` indicating the name of a seeding algorithm (see
@@ -78,12 +78,10 @@ function kmedoids(costs::DenseMatrix{T}, k::Integer;
 end
 
 """
-    kmedoids!(costs::DenseMatrix, medoids::Vector{Int}; [kwargs...])
+    kmedoids!(costs::DenseMatrix, medoids::Vector{Int};
+              [kwargs...]) -> KmedoidsResult
 
-Performs K-medoids clustering starting with the provided indices of initial
-`medoids`.
-
-Returns [`KmedoidsResult`](@ref) object and updates the `medoids` indices in-place.
+Update the current cluster `medoids` using the `costs` matrix.
 
 See [`kmedoids`](@ref) for the description of optional `kwargs`.
 """

--- a/src/mcl.jl
+++ b/src/mcl.jl
@@ -1,6 +1,8 @@
 # MCL (Markov CLustering algorithm)
 
 """
+    MCLResult <: ClusteringResult
+
 The output of [`mcl`](@ref) function.
 
 # Fields
@@ -121,14 +123,13 @@ function _mcl_prune!(mtx::AbstractMatrix, prune_tol::Number)
 end
 
 """
-    mcl(adj::AbstractMatrix; [kwargs...])
+    mcl(adj::AbstractMatrix; [kwargs...]) -> MCLResult
 
 Perform MCL (Markov Cluster Algorithm) clustering using ``n×n``
 adjacency (points similarity) matrix `adj`.
 
-Returns [`MCLResult`](@ref) object.
-
-# Algorithm Options
+# Arguments
+Keyword arguments to control the MCL algorithm:
  - `add_loops::Bool` (enabled by default): whether the edges of weight 1.0
    from the node to itself should be appended to the graph
  - `expansion::Number` (defaults to 2): MCL *expansion* constant
@@ -141,7 +142,7 @@ Returns [`MCLResult`](@ref) object.
    for diagnostic messages
  - `max_iter`, `tol`: see [common options](@ref common_options)
 
-### References
+# References
 > Stijn van Dongen, *"Graph clustering by flow simulation"*, 2001
 
 > [Original MCL implementation](http://micans.org/mcl).

--- a/src/randindex.jl
+++ b/src/randindex.jl
@@ -1,5 +1,5 @@
 """
-    randindex(c1, c2)
+    randindex(c1, c2) -> NTuple{4, Float64}
 
 Compute the tuple of Rand-related indices between the clusterings `c1` and `c2`.
 
@@ -11,6 +11,13 @@ Returns a tuple of indices:
   - Rand index
   - Mirkin's index
   - Hubert's index
+
+# References
+> Lawrence Hubert and Phipps Arabie (1985). *Comparing partitions.*
+> Journal of Classification 2 (1): 193–218
+
+> Meila, Marina (2003). *Comparing Clusterings by the Variation of
+> Information.* Learning Theory and Kernel Machines: 173–187.
 """
 function randindex(c1,c2)
     c = counts(c1,c2,(1:maximum(c1),1:maximum(c2))) # form contingency matrix

--- a/src/silhouette.jl
+++ b/src/silhouette.jl
@@ -20,8 +20,8 @@ end
 
 
 """
-    silhouettes(assignments::AbstractVector, [counts,] dists)
-    silhouettes(clustering::ClusteringResult, dists)
+    silhouettes(assignments::AbstractVector, [counts,] dists) -> Vector{Float64}
+    silhouettes(clustering::ClusteringResult, dists) -> Vector{Float64}
 
 Compute *silhouette* values for individual points w.r.t. given clustering.
 
@@ -35,6 +35,11 @@ Returns the ``n``-length vector of silhouette values for each individual point.
  - `clustering::ClusteringResult`: the output of some clustering method
  - `dists::AbstractMatrix`: ``n×n`` matrix of pairwise distances between
    the points
+
+# References
+> Peter J. Rousseeuw (1987). *Silhouettes: a Graphical Aid to the
+> Interpretation and Validation of Cluster Analysis*. Computational and
+> Applied Mathematics. 20: 53–65.
 """
 function silhouettes(assignments::AbstractVector{<:Integer},
                      counts::AbstractVector{<:Integer},

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,6 +3,8 @@
 ##### common types
 
 """
+    ClusteringResult
+
 Base type for the output of clustering algorithm.
 """
 abstract type ClusteringResult end
@@ -10,14 +12,14 @@ abstract type ClusteringResult end
 # generic functions
 
 """
-    nclusters(R::ClusteringResult)
+    nclusters(R::ClusteringResult) -> Int
 
 Get the number of clusters.
 """
 nclusters(R::ClusteringResult) = length(R.counts)
 
 """
-    counts(R::ClusteringResult)
+    counts(R::ClusteringResult) -> Vector{Int}
 
 Get the vector of cluster sizes.
 
@@ -26,7 +28,7 @@ Get the vector of cluster sizes.
 counts(R::ClusteringResult) = R.counts
 
 """
-    assignments(R::ClusteringResult)
+    assignments(R::ClusteringResult) -> Vector{Int}
 
 Get the vector of cluster indices for each point.
 

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -1,9 +1,9 @@
 # Variation of Information
 
 """
-    varinfo(k1::Int, a1::AbstractVector{Int}, k2::Int, a2::AbstractVector{Int})
-    varinfo(R::ClusteringResult, k0::Int, a0::AbstractVector{Int})
-    varinfo(R1::ClusteringResult, R2::ClusteringResult)
+    varinfo(k1::Int, a1::AbstractVector{Int}, k2::Int, a2::AbstractVector{Int}) -> Float64
+    varinfo(R::ClusteringResult, k0::Int, a0::AbstractVector{Int}) -> Float64
+    varinfo(R1::ClusteringResult, R2::ClusteringResult) -> Float64
 
 Compute the variation of information between the two clusterings.
 
@@ -11,6 +11,10 @@ Each clustering is provided either as an instance of [`ClusteringResult`](@ref)
 subtype or as a pair of arguments:
  - a number of clusters (`k1`, `k2`, `k0`)
  - a vector of point to cluster assignments (`a1`, `a2`, `a0`).
+
+# References
+> Meila, Marina (2003). *Comparing Clusterings by the Variation of
+> Information.* Learning Theory and Kernel Machines: 173–187.
 """
 function varinfo(k1::Int, a1::AbstractVector{Int},
                  k2::Int, a2::AbstractVector{Int})

--- a/src/vmeasure.jl
+++ b/src/vmeasure.jl
@@ -25,7 +25,7 @@ function _vmeasure(A::AbstractMatrix{<:Integer}; β::Real)
 end
 
 """
-    vmeasure(assign1, assign2; [β = 1.0])
+    vmeasure(assign1, assign2; [β = 1.0]) -> Float64
 
 V-measure between two clustering assignments.
 
@@ -36,10 +36,9 @@ The `β` parameter defines trade-off between _homogeneity_ and _completeness_:
  * if ``β > 1``, _completeness_ is weighted more strongly,
  * if ``β < 1``, _homogeneity_ is weighted more strongly.
 
-#### References
-
-> Andrew Rosenberg and Julia Hirschberg, 2007. *"V-Measure: A conditional
-> entropy-based external cluster evaluation measure"*
+# References
+> Andrew Rosenberg and Julia Hirschberg, 2007. *V-Measure: A conditional
+> entropy-based external cluster evaluation measure*
 """
 function vmeasure(assign1::Union{AbstractVector{<:Integer}, ClusteringResult},
                   assign2::Union{AbstractVector{<:Integer}, ClusteringResult};


### PR DESCRIPTION
Docstrings and Documenter .md files cleanups:
- address @nalimilan comments from #155
- consistently use `# Arguments` and `# References` section titles
- try to move paper references from .md into corresponding docstrings
- `func() -> output` format to document the return type in docstrings
- add the first (code) line to the docstrings of types