### PR TITLE
wcounts() and tiny FuzzyCMeans API cleanups

### DIFF
--- a/doc/source/algorithms.md
+++ b/doc/source/algorithms.md
@@ -51,5 +51,6 @@ The following generic methods are supported by any subtype of `ClusteringResult`
 ```@docs
 nclusters(::ClusteringResult)
 counts(::ClusteringResult)
+wcounts(::ClusteringResult)
 assignments(::ClusteringResult)
 ```

--- a/doc/source/fuzzycmeans.md
+++ b/doc/source/fuzzycmeans.md
@@ -19,6 +19,7 @@ and ``m > 1`` is a user-defined fuzziness parameter.
 ```@docs
 fuzzy_cmeans
 FuzzyCMeansResult
+wcounts(::FuzzyCMeansResult)
 ```
 
 ## Examples

--- a/src/Clustering.jl
+++ b/src/Clustering.jl
@@ -17,7 +17,7 @@ module Clustering
 
     # common
     ClusteringResult,
-    nclusters, counts, assignments,
+    nclusters, counts, wcounts, assignments,
 
     # seeding
     SeedingAlgorithm,

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -35,3 +35,20 @@ Base.propertynames(hclu::Hclust, private::Bool = false) =
         return getfield(hclu, prop)
     end
 end
+
+# FIXME remove after deprecation period for cweights
+Base.propertynames(clu::KmeansResult, private::Bool = false) =
+    (:centers, :assignments, :costs, :counts, :wcounts,
+     :totalcost, :iterations, :converged,
+     #= deprecated as of 0.13.2 =# :cweights)
+
+# FIXME remove after deprecation period for cweights
+@inline function Base.getproperty(clu::KmeansResult, prop::Symbol)
+    if prop === :cweights
+        Base.depwarn("KmeansResult::cweights is deprecated, use wcounts(clu::KmeansResult)",
+                     Symbol("KmeansResult::cweights"))
+        return clu.wcounts
+    else
+        return getfield(clu, prop)
+    end
+end

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -11,3 +11,27 @@
 @deprecate varinfo(k1::Int, a1::AbstractVector{Int},
                    k2::Int, a2::AbstractVector{Int}) varinfo(a1, a2)
 @deprecate varinfo(R::ClusteringResult, k0::Int, a0::AbstractVector{Int}) varinfo(R, a0)
+
+# FIXME remove after deprecation period for merge/labels/height/method
+Base.propertynames(hclu::Hclust, private::Bool = false) =
+    (:merges, :heights, :order, :linkage,
+     #= deprecated as of 0.12 =# :height, :labels, :merge, :method)
+
+# FIXME remove after deprecation period for merge/labels/height/method
+@inline function Base.getproperty(hclu::Hclust, prop::Symbol)
+    if prop === :height
+        Base.depwarn("Hclust::height is deprecated, use Hclust::heights", Symbol("Hclust::height"))
+        return getfield(hclu, :heights)
+    elseif prop === :labels
+        Base.depwarn("Hclust::labels is deprecated and will be removed in future versions", Symbol("Hclust::labels"))
+        return 1:nnodes(hclu)
+    elseif prop === :merge
+        Base.depwarn("Hclust::merge is deprecated, use Hclust::merges", Symbol("Hclust::merge"))
+        return getfield(hclu, :merges)
+    elseif prop === :method
+        Base.depwarn("Hclust::method is deprecated, use Hclust::linkage", Symbol("Hclust::method"))
+        return getfield(hclu, :linkage)
+    else
+        return getfield(hclu, prop)
+    end
+end

--- a/src/fuzzycmeans.jl
+++ b/src/fuzzycmeans.jl
@@ -23,6 +23,10 @@ struct FuzzyCMeansResult{T<:AbstractFloat}
     converged::Bool             # whether the procedure converged
 end
 
+nclusters(R::FuzzyCMeansResult) = size(R.centers, 2)
+
+wcounts(R::FuzzyCMeansResult) = dropdims(sum(R.weights, dims=2), dims=2)
+
 ## Utility functions
 
 function update_weights!(weights, data, centers, fuzziness, dist_metric)

--- a/src/fuzzycmeans.jl
+++ b/src/fuzzycmeans.jl
@@ -3,7 +3,7 @@
 ## Interface
 
 """
-    FuzzyCMeansResult{T<:AbstractFloat} <: ClusteringResult
+    FuzzyCMeansResult{T<:AbstractFloat}
 
 The output of [`fuzzy_cmeans`](@ref) function.
 
@@ -16,7 +16,7 @@ The output of [`fuzzy_cmeans`](@ref) function.
 - `iterations::Int`: the number of executed algorithm iterations
 - `converged::Bool`: whether the procedure converged
 """
-struct FuzzyCMeansResult{T<:AbstractFloat} <: ClusteringResult
+struct FuzzyCMeansResult{T<:AbstractFloat}
     centers::Matrix{T}          # cluster centers (d x C)
     weights::Matrix{Float64}    # assigned weights (n x C)
     iterations::Int             # number of elasped iterations

--- a/src/hclust.jl
+++ b/src/hclust.jl
@@ -42,30 +42,6 @@ nmerges(h::Hclust) = length(h.heights)  # number of tree merges
 nnodes(h::Hclust) = length(h.order)     # number of datapoints (leaf nodes)
 height(h::Hclust) = isempty(h.heights) ? typemin(eltype(h.heights)) : last(h.heights)
 
-# FIXME remove after deprecation period for merge/height/method
-Base.propertynames(hclu::Hclust, private::Bool = false) =
-    (:merges, :heights, :order, :linkage,
-     #= deprecated =# :height, :labels, :merge, :method)
-
-# FIXME remove after deprecation period for height/labels/merge/method
-function Base.getproperty(hclu::Hclust, prop::Symbol)
-    if prop == :height
-        Base.depwarn("Hclust::height is deprecated, use Hclust::heights", Symbol("Hclust::height"))
-        return getfield(hclu, :heights)
-    elseif prop == :labels
-        Base.depwarn("Hclust::labels is deprecated and will be removed in future versions", Symbol("Hclust::labels"))
-        return 1:nnodes(hclu)
-    elseif prop == :merge
-        Base.depwarn("Hclust::merge is deprecated, use Hclust::merges", Symbol("Hclust::merge"))
-        return getfield(hclu, :merges)
-    elseif prop == :method
-        Base.depwarn("Hclust::method is deprecated, use Hclust::linkage", Symbol("Hclust::method"))
-        return getfield(hclu, :linkage)
-    else
-        return getfield(hclu, prop)
-    end
-end
-
 function assertdistancematrix(d::AbstractMatrix)
     nr, nc = size(d)
     nr == nc || throw(DimensionMismatch("Distance matrix should be square."))

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -27,23 +27,6 @@ struct KmeansResult{C<:AbstractMatrix{<:AbstractFloat},D<:Real,WC<:Real} <: Clus
     converged::Bool            # whether the procedure converged
 end
 
-# FIXME remove after deprecation period for cweights
-Base.propertynames(clu::KmeansResult, private::Bool = false) =
-    (:centers, :assignments, :costs, :counts, :wcounts,
-     :totalcost, :iterations, :converged,
-     #= deprecated as of 0.13.2 =# :cweights)
-
-# FIXME remove after deprecation period for cweights
-function Base.getproperty(clu::KmeansResult, prop::Symbol)
-    if prop == :cweights
-        Base.depwarn("KmeansResult::cweights is deprecated, use wcounts(clu::KmeansResult)",
-                     Symbol("KmeansResult::cweights"))
-        return clu.wcounts
-    else
-        return getfield(clu, prop)
-    end
-end
-
 wcounts(clu::KmeansResult) = clu.wcounts
 
 const _kmeans_default_init = :kmpp

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -27,6 +27,8 @@ struct KmeansResult{C<:AbstractMatrix{<:AbstractFloat},D<:Real,WC<:Real} <: Clus
     converged::Bool            # whether the procedure converged
 end
 
+wcounts(clu::KmeansResult) = clu.cweights
+
 const _kmeans_default_init = :kmpp
 const _kmeans_default_maxiter = 100
 const _kmeans_default_tol = 1.0e-6

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,6 +28,17 @@ Get the vector of cluster sizes.
 counts(R::ClusteringResult) = R.counts
 
 """
+    wcounts(R::ClusteringResult) -> Vector{Float64}
+
+Get the weighted cluster sizes as the sum of weights of points assigned to each
+cluster.
+
+For non-weighted clusterings assumes the weight of every data point is 1.0,
+so the result is equivalent to `convert(Vector{Float64}, counts(R))`.
+"""
+wcounts(R::ClusteringResult) = convert(Vector{Float64}, counts(R))
+
+"""
     assignments(R::ClusteringResult) -> Vector{Int}
 
 Get the vector of cluster indices for each point.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -29,6 +29,7 @@ counts(R::ClusteringResult) = R.counts
 
 """
     wcounts(R::ClusteringResult) -> Vector{Float64}
+    wcounts(R::FuzzyCMeansResult) -> Vector{Float64}
 
 Get the weighted cluster sizes as the sum of weights of points assigned to each
 cluster.

--- a/test/fuzzycmeans.jl
+++ b/test/fuzzycmeans.jl
@@ -15,18 +15,18 @@ end
 
 Random.seed!(34568)
 
-m = 3
+d = 3
 n = 1000
 k = 5
 
-x = rand(m, n)
+x = rand(d, n)
 
 @testset "fuzziness = 2.0" begin
     fuzziness = 2.0
     Random.seed!(34568)
     r = fuzzy_cmeans(x, k, fuzziness)
     @test isa(r, FuzzyCMeansResult{Float64})
-    @test size(r.centers) == (m, k)
+    @test size(r.centers) == (d, k)
     @test size(r.weights) == (n, k)
     @test sum(r.weights, dims=2) ≈ fill(1.0, n)
     @test all(0 .<= r.weights .<= 1)
@@ -37,7 +37,7 @@ end
     Random.seed!(34568)
     r = fuzzy_cmeans(x, k, fuzziness)
     @test isa(r, FuzzyCMeansResult{Float64})
-    @test size(r.centers) == (m, k)
+    @test size(r.centers) == (d, k)
     @test size(r.weights) == (n, k)
     @test sum(r.weights, dims=2) ≈ fill(1.0, n)
     @test all(0 .<= r.weights .<= 1)
@@ -48,7 +48,7 @@ end
     Random.seed!(34568)
     r = fuzzy_cmeans(view(x, :, :), k, fuzziness)
     @test isa(r, FuzzyCMeansResult{Float64})
-    @test size(r.centers) == (m, k)
+    @test size(r.centers) == (d, k)
     @test size(r.weights) == (n, k)
     @test sum(r.weights, dims=2) ≈ fill(1.0, n)
     @test all(0 .<= r.weights .<= 1)

--- a/test/fuzzycmeans.jl
+++ b/test/fuzzycmeans.jl
@@ -26,10 +26,16 @@ x = rand(d, n)
     Random.seed!(34568)
     r = fuzzy_cmeans(x, k, fuzziness)
     @test isa(r, FuzzyCMeansResult{Float64})
+    @test nclusters(r) == k
     @test size(r.centers) == (d, k)
     @test size(r.weights) == (n, k)
-    @test sum(r.weights, dims=2) ≈ fill(1.0, n)
     @test all(0 .<= r.weights .<= 1)
+    @test sum(r.weights, dims=2) ≈ fill(1.0, n)
+
+    @test wcounts(r) isa Vector{Float64}
+    @test length(wcounts(r)) == n
+    @test all(0 .<= wcounts(r) .<= n)
+    @test sum(wcounts(r)) ≈ n
 end
 
 @testset "fuzziness = 3.0" begin
@@ -37,10 +43,16 @@ end
     Random.seed!(34568)
     r = fuzzy_cmeans(x, k, fuzziness)
     @test isa(r, FuzzyCMeansResult{Float64})
+    @test nclusters(r) == k
     @test size(r.centers) == (d, k)
     @test size(r.weights) == (n, k)
     @test sum(r.weights, dims=2) ≈ fill(1.0, n)
     @test all(0 .<= r.weights .<= 1)
+
+    @test wcounts(r) isa Vector{Float64}
+    @test length(wcounts(r)) == n
+    @test all(0 .<= wcounts(r) .<= n)
+    @test sum(wcounts(r)) ≈ n
 end
 
 @testset "Abstract data matrix" begin
@@ -48,10 +60,16 @@ end
     Random.seed!(34568)
     r = fuzzy_cmeans(view(x, :, :), k, fuzziness)
     @test isa(r, FuzzyCMeansResult{Float64})
+    @test nclusters(r) == k
     @test size(r.centers) == (d, k)
     @test size(r.weights) == (n, k)
     @test sum(r.weights, dims=2) ≈ fill(1.0, n)
     @test all(0 .<= r.weights .<= 1)
+
+    @test wcounts(r) isa Vector{Float64}
+    @test length(wcounts(r)) == n
+    @test all(0 .<= wcounts(r) .<= n)
+    @test sum(wcounts(r)) ≈ n
 end
 
 end

--- a/test/fuzzycmeans.jl
+++ b/test/fuzzycmeans.jl
@@ -19,15 +19,15 @@ m = 3
 n = 1000
 k = 5
 
-x = rand(m,n)
+x = rand(m, n)
 
 @testset "fuzziness = 2.0" begin
     fuzziness = 2.0
     Random.seed!(34568)
     r = fuzzy_cmeans(x, k, fuzziness)
     @test isa(r, FuzzyCMeansResult{Float64})
-    @test size(r.centers) == (m,k)
-    @test size(r.weights) == (n,k)
+    @test size(r.centers) == (m, k)
+    @test size(r.weights) == (n, k)
     @test sum(r.weights, dims=2) ≈ fill(1.0, n)
     @test all(0 .<= r.weights .<= 1)
 end
@@ -37,8 +37,8 @@ end
     Random.seed!(34568)
     r = fuzzy_cmeans(x, k, fuzziness)
     @test isa(r, FuzzyCMeansResult{Float64})
-    @test size(r.centers) == (m,k)
-    @test size(r.weights) == (n,k)
+    @test size(r.centers) == (m, k)
+    @test size(r.weights) == (n, k)
     @test sum(r.weights, dims=2) ≈ fill(1.0, n)
     @test all(0 .<= r.weights .<= 1)
 end
@@ -48,8 +48,8 @@ end
     Random.seed!(34568)
     r = fuzzy_cmeans(view(x, :, :), k, fuzziness)
     @test isa(r, FuzzyCMeansResult{Float64})
-    @test size(r.centers) == (m,k)
-    @test size(r.weights) == (n,k)
+    @test size(r.centers) == (m, k)
+    @test size(r.weights) == (n, k)
     @test sum(r.weights, dims=2) ≈ fill(1.0, n)
     @test all(0 .<= r.weights .<= 1)
 end

--- a/test/kmeans.jl
+++ b/test/kmeans.jl
@@ -48,13 +48,14 @@ equal_kmresults(km1::KmeansResult, km2::KmeansResult) =
     Random.seed!(34568)
     r = kmeans(x, k; maxiter=50)
     @test isa(r, KmeansResult{Matrix{Float64}, Float64, Int})
+    @test nclusters(r) == k
     @test size(r.centers) == (m, k)
     @test length(r.assignments) == n
     @test all(a -> 1 <= a <= k, r.assignments)
     @test length(r.costs) == n
-    @test length(r.counts) == k
-    @test sum(r.counts) == n
-    @test r.cweights == r.counts
+    @test length(counts(r)) == k
+    @test sum(counts(r)) == n
+    @test r.cweights == counts(r)
     @test sum(r.costs) ≈ r.totalcost
 
     Random.seed!(34568)
@@ -68,13 +69,14 @@ end
     x32t = copy(x32')
     r = kmeans(x32, k; maxiter=50)
     @test isa(r, KmeansResult{Matrix{Float32}, Float32, Int})
+    @test nclusters(r) == k
     @test size(r.centers) == (m, k)
     @test length(r.assignments) == n
     @test all(a -> 1 <= a <= k, r.assignments)
     @test length(r.costs) == n
-    @test length(r.counts) == k
-    @test sum(r.counts) == n
-    @test r.cweights == r.counts
+    @test length(counts(r)) == k
+    @test sum(counts(r)) == n
+    @test r.cweights == counts(r)
     @test sum(r.costs) ≈ r.totalcost
 
     Random.seed!(34568)
@@ -87,12 +89,13 @@ end
     Random.seed!(34568)
     r = kmeans(x, k; maxiter=50, weights=w)
     @test isa(r, KmeansResult{Matrix{Float64}, Float64, Float64})
+    @test nclusters(r) == k
     @test size(r.centers) == (m, k)
     @test length(r.assignments) == n
     @test all(a -> 1 <= a <= k, r.assignments)
     @test length(r.costs) == n
-    @test length(r.counts) == k
-    @test sum(r.counts) == n
+    @test length(counts(r)) == k
+    @test sum(counts(r)) == n
 
     cw = zeros(k)
     for i = 1:n
@@ -111,13 +114,14 @@ end
     r = kmeans(x, k; maxiter=50, init=:kmcen, distance=MySqEuclidean())
     r2 = kmeans(x, k; maxiter=50, init=:kmcen)
     @test isa(r, KmeansResult{Matrix{Float64}, Float64, Int})
+    @test nclusters(r) == k
     @test size(r.centers) == (m, k)
     @test length(r.assignments) == n
     @test all(a -> 1 <= a <= k, r.assignments)
     @test length(r.costs) == n
-    @test length(r.counts) == k
-    @test sum(r.counts) == n
-    @test r.cweights == r.counts
+    @test length(counts(r)) == k
+    @test sum(counts(r)) == n
+    @test r.cweights == counts(r)
     @test sum(r.costs) ≈ r.totalcost
     @test equal_kmresults(r, r2)
 

--- a/test/kmeans.jl
+++ b/test/kmeans.jl
@@ -55,7 +55,7 @@ equal_kmresults(km1::KmeansResult, km2::KmeansResult) =
     @test length(r.costs) == n
     @test length(counts(r)) == k
     @test sum(counts(r)) == n
-    @test r.cweights == counts(r)
+    @test wcounts(r) == counts(r)
     @test sum(r.costs) ≈ r.totalcost
 
     Random.seed!(34568)
@@ -76,7 +76,7 @@ end
     @test length(r.costs) == n
     @test length(counts(r)) == k
     @test sum(counts(r)) == n
-    @test r.cweights == counts(r)
+    @test wcounts(r) == counts(r)
     @test sum(r.costs) ≈ r.totalcost
 
     Random.seed!(34568)
@@ -101,7 +101,7 @@ end
     for i = 1:n
         cw[r.assignments[i]] += w[i]
     end
-    @test r.cweights ≈ cw
+    @test wcounts(r) ≈ cw
     @test dot(r.costs, w) ≈ r.totalcost
 
     Random.seed!(34568)
@@ -121,7 +121,7 @@ end
     @test length(r.costs) == n
     @test length(counts(r)) == k
     @test sum(counts(r)) == n
-    @test r.cweights == counts(r)
+    @test wcounts(r) == r.counts
     @test sum(r.costs) ≈ r.totalcost
     @test equal_kmresults(r, r2)
 

--- a/test/kmedoids.jl
+++ b/test/kmedoids.jl
@@ -34,6 +34,7 @@ R = kmedoids(costs, k)
 @test all(a -> 1 <= a <= k, R.assignments)
 @test R.assignments[R.medoids] == 1:k # Every medoid should belong to its own cluster
 @test sum(counts(R)) == n
+@test wcounts(R) == counts(R)
 @test R.acosts == costs[LinearIndices((n, n))[CartesianIndex.(R.medoids[R.assignments], 1:n)]]
 @test isapprox(sum(R.acosts), R.totalcost)
 @test R.converged
@@ -54,6 +55,7 @@ R = kmedoids!(costs, [1, 2, 6])
 @test R.medoids == [3, 5, 6]
 @test R.assignments == [1, 2, 1, 1, 2, 3, 2, 3, 3]
 @test counts(R) == [3, 3, 3]
+@test wcounts(R) == counts(R)
 @test R.acosts ≈ [1, 1, 0, 1, 0, 0, 1, 1, 1]
 @test R.totalcost ≈ 6.0
 @test R.converged

--- a/test/kmedoids.jl
+++ b/test/kmedoids.jl
@@ -29,10 +29,11 @@ costs = pairwise(SqEuclidean(), X, dims=2)
 
 R = kmedoids(costs, k)
 @test isa(R, KmedoidsResult)
+@test nclusters(R) == k
 @test length(R.medoids) == length(unique(R.medoids))
 @test all(a -> 1 <= a <= k, R.assignments)
-@test R.assignments[R.medoids] == collect(1:k) # Every medoid should belong to its own cluster
-@test sum(R.counts) == n
+@test R.assignments[R.medoids] == 1:k # Every medoid should belong to its own cluster
+@test sum(counts(R)) == n
 @test R.acosts == costs[LinearIndices((n, n))[CartesianIndex.(R.medoids[R.assignments], 1:n)]]
 @test isapprox(sum(R.acosts), R.totalcost)
 @test R.converged
@@ -49,9 +50,10 @@ costs = pairwise(SqEuclidean(), X, dims=2)
 
 R = kmedoids!(costs, [1, 2, 6])
 @test isa(R, KmedoidsResult)
+@test nclusters(R) == 3
 @test R.medoids == [3, 5, 6]
 @test R.assignments == [1, 2, 1, 1, 2, 3, 2, 3, 3]
-@test R.counts == [3, 3, 3]
+@test counts(R) == [3, 3, 3]
 @test R.acosts ≈ [1, 1, 0, 1, 0, 0, 1, 1, 1]
 @test R.totalcost ≈ 6.0
 @test R.converged


### PR DESCRIPTION
Some small counts/weights API improvements:
 * add `wcounts(ClusteringResult)` (sum of the point weights)
 * add `wcounts(FuzzyCMeansResult)` and `nclusters(FuzzyCMeansResult)`
 * `FuzzyCMeansResult` is not a `ClusteringResult` (cannot have counts or assignments)
 * rename `KMeansResult.cweights` into `KMeansResult.wcounts` for consistency (old property is still supported but deprecated)
