### PR TITLE
The k-means style k-medoids is known to produce worse results

### DIFF
--- a/src/kmedoids.jl
+++ b/src/kmedoids.jl
@@ -47,7 +47,7 @@ assigning `j`-th point to the medoid represented by the `i`-th point).
 
 # Note
 This package implements a K-means style algorithm instead of PAM, which
-is considered much more efficient and reliable.
+converges in fewer iterations, but was shown to produce worse results.
 
 # Arguments
  - `init` (defaults to `:kmpp`): how medoids should be initialized, could


### PR DESCRIPTION
The Maranzana approach produces worse results (even 10-20% worse total deviation). See, e.g.,
Teitz, Michael B.; Bart, Polly (1968-10-01). "Heuristic Methods for Estimating the Generalized Vertex Median of a Weighted Graph". Operations Research. 16 (5): 955–961. doi:10.1287/opre.16.5.955. ISSN 0030-364X.
Schubert, Erich, and Peter J. Rousseeuw. "Faster k-medoids clustering: Improving the pam, clara, and clarans algorithms." SISAP, 2019. doi:10.1007/978-3-030-32047-8_16
this is because it gets stuck in local optima easily (hence few iterations, hence "fast"), while the classic PAM algorithm can further improve the result with its swap approach.