### PR TITLE
Cleanup deprecations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Clustering"
 uuid = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
-version = "0.13.3"
+version = "0.13.4"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -14,21 +14,21 @@
 
 # FIXME remove after deprecation period for merge/labels/height/method
 Base.propertynames(hclu::Hclust, private::Bool = false) =
-    (:merges, :heights, :order, :linkage,
+    (fieldnames(hclu)...,
      #= deprecated as of 0.12 =# :height, :labels, :merge, :method)
 
 # FIXME remove after deprecation period for merge/labels/height/method
 @inline function Base.getproperty(hclu::Hclust, prop::Symbol)
-    if prop === :height
+    if prop === :height # deprecated as of 0.12
         Base.depwarn("Hclust::height is deprecated, use Hclust::heights", Symbol("Hclust::height"))
         return getfield(hclu, :heights)
-    elseif prop === :labels
+    elseif prop === :labels # deprecated as of 0.12
         Base.depwarn("Hclust::labels is deprecated and will be removed in future versions", Symbol("Hclust::labels"))
         return 1:nnodes(hclu)
-    elseif prop === :merge
+    elseif prop === :merge # deprecated as of 0.12
         Base.depwarn("Hclust::merge is deprecated, use Hclust::merges", Symbol("Hclust::merge"))
         return getfield(hclu, :merges)
-    elseif prop === :method
+    elseif prop === :method # deprecated as of 0.12
         Base.depwarn("Hclust::method is deprecated, use Hclust::linkage", Symbol("Hclust::method"))
         return getfield(hclu, :linkage)
     else
@@ -38,13 +38,11 @@ end
 
 # FIXME remove after deprecation period for cweights
 Base.propertynames(clu::KmeansResult, private::Bool = false) =
-    (:centers, :assignments, :costs, :counts, :wcounts,
-     :totalcost, :iterations, :converged,
-     #= deprecated as of 0.13.2 =# :cweights)
+    (fieldnames(clu)..., #= deprecated as of 0.13.2 =# :cweights)
 
 # FIXME remove after deprecation period for cweights
 @inline function Base.getproperty(clu::KmeansResult, prop::Symbol)
-    if prop === :cweights
+    if prop === :cweights # deprecated as of 0.13.2
         Base.depwarn("KmeansResult::cweights is deprecated, use wcounts(clu::KmeansResult)",
                      Symbol("KmeansResult::cweights"))
         return clu.wcounts

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -50,3 +50,18 @@ Base.propertynames(clu::KmeansResult, private::Bool = false) =
         return getfield(clu, prop)
     end
 end
+
+# FIXME remove after deprecation period for acosts
+Base.propertynames(kmed::KmedoidsResult, private::Bool = false) =
+    (fieldnames(kmed)..., #= deprecated since v0.13.4=# :acosts)
+
+# FIXME remove after deprecation period for acosts
+function Base.getproperty(kmed::KmedoidsResult, prop::Symbol)
+    if prop == :acosts # deprecated since v0.13.4
+        Base.depwarn("KmedoidsResult::acosts is deprecated, use KmedoidsResult::costs",
+                     Symbol("KmedoidsResult::costs"))
+        return getfield(kmed, :costs)
+    else
+        return getfield(kmed, prop)
+    end
+end

--- a/src/kmedoids.jl
+++ b/src/kmedoids.jl
@@ -30,21 +30,6 @@ mutable struct KmedoidsResult{T} <: ClusteringResult
     converged::Bool             # whether the procedure converged
 end
 
-# FIXME remove after deprecation period for acosts
-Base.propertynames(kmed::KmedoidsResult, private::Bool = false) =
-    (fieldnames(kmed)..., #= deprecated since v0.13.4=# :acosts)
-
-# FIXME remove after deprecation period for acosts
-function Base.getproperty(kmed::KmedoidsResult, prop::Symbol)
-    if prop == :acosts # deprecated since v0.13.4
-        Base.depwarn("KmedoidsResult::acosts is deprecated, use KmedoidsResult::costs", Symbol("KmedoidsResult::costs"))
-        return getfield(kmed, :costs)
-    else
-        return getfield(kmed, prop)
-    end
-end
-
-
 #### interface functions
 
 const _kmed_default_init = :kmpp


### PR DESCRIPTION
* Use `fieldnames()` to simplify property deprecations
* Add missing comments annotating deprecations with the package version it was introduced
* Move `KmedoidsResult` deprecations to `deprecate.jl`