### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,9 @@ julia:
   - 1.0
   - 1
   - nightly
-matrix:
+jobs:
   allow_failures:
     - julia: nightly
-notifications:
-  email: false
-# uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'using Pkg; Pkg.add(pwd()); Pkg.build("Clustering"); Pkg.test("Clustering"; coverage=true)'
-after_success:
-  - julia -e 'using Pkg, Clustering; cd(joinpath(dirname(pathof(Clustering)), "..")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
-
-jobs:
   include:
     - stage: "Documentation"
       julia: 1
@@ -28,3 +18,11 @@ jobs:
         - julia --project=doc/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate();'
         - julia --project=doc/ doc/make.jl
       after_success: skip
+notifications:
+  email: false
+# uncomment the following lines to override the default test script
+#script:
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'using Pkg; Pkg.add(pwd()); Pkg.build("Clustering"); Pkg.test("Clustering"; coverage=true)'
+after_success:
+  - julia -e 'using Pkg, Clustering; cd(joinpath(dirname(pathof(Clustering)), "..")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.1
+  - 1
   - nightly
 matrix:
   allow_failures:
@@ -22,7 +22,7 @@ after_success:
 jobs:
   include:
     - stage: "Documentation"
-      julia: 1.1
+      julia: 1
       os: linux
       script:
         - julia --project=doc/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate();'


### PR DESCRIPTION
Fix the clash of *matrix* and *jobs* sections in *.travis.yml*, which resulted in documentation not being built.
Also switch from the hardcoded Julia v1.1 to the latest stable in 1.x series for CI, and use this version for docs generation.