### PR TITLE
Fix propertynames() methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Clustering"
 uuid = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
-version = "0.13.4"
+version = "0.13.5"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -14,7 +14,7 @@
 
 # FIXME remove after deprecation period for merge/labels/height/method
 Base.propertynames(hclu::Hclust, private::Bool = false) =
-    (fieldnames(hclu)...,
+    (fieldnames(typeof(hclu))...,
      #= deprecated as of 0.12 =# :height, :labels, :merge, :method)
 
 # FIXME remove after deprecation period for merge/labels/height/method
@@ -38,7 +38,7 @@ end
 
 # FIXME remove after deprecation period for cweights
 Base.propertynames(clu::KmeansResult, private::Bool = false) =
-    (fieldnames(clu)..., #= deprecated as of 0.13.2 =# :cweights)
+    (fieldnames(typeof(clu))..., #= deprecated as of 0.13.2 =# :cweights)
 
 # FIXME remove after deprecation period for cweights
 @inline function Base.getproperty(clu::KmeansResult, prop::Symbol)
@@ -53,7 +53,7 @@ end
 
 # FIXME remove after deprecation period for acosts
 Base.propertynames(kmed::KmedoidsResult, private::Bool = false) =
-    (fieldnames(kmed)..., #= deprecated since v0.13.4=# :acosts)
+    (fieldnames(typeof(kmed))..., #= deprecated since v0.13.4=# :acosts)
 
 # FIXME remove after deprecation period for acosts
 function Base.getproperty(kmed::KmedoidsResult, prop::Symbol)


### PR DESCRIPTION
The should call `fieldnames(typeof(x))` instead of `fieldnames(x)`

fixes #191