### PR TITLE
Make accept AbstractMatrix

### DIFF
--- a/src/affprop.jl
+++ b/src/affprop.jl
@@ -33,7 +33,7 @@ const _afp_default_tol = 1.0e-6
 const _afp_default_display = :none
 
 """
-    affinityprop(S::DenseMatrix; [maxiter=200], [tol=1e-6], [damp=0.5],
+    affinityprop(S::AbstractMatrix; [maxiter=200], [tol=1e-6], [damp=0.5],
                  [display=:none]) -> AffinityPropResult
 
 Perform affinity propagation clustering based on a similarity matrix `S`.
@@ -52,7 +52,7 @@ of the ``i``-th point as an *exemplar*.
 > Brendan J. Frey and Delbert Dueck. *Clustering by Passing Messages
 > Between Data Points.* Science, vol 315, pages 972-976, 2007.
 """
-function affinityprop(S::DenseMatrix{T};
+function affinityprop(S::AbstractMatrix{T};
                       maxiter::Integer=_afp_default_maxiter,
                       tol::Real=_afp_default_tol,
                       damp::Real=_afp_default_damp,
@@ -72,7 +72,7 @@ end
 
 #### Implementation
 
-function _affinityprop(S::DenseMatrix{T},
+function _affinityprop(S::AbstractMatrix{T},
                        maxiter::Int,
                        tol::Real,
                        damp::T,
@@ -134,7 +134,7 @@ end
 
 
 # compute responsibilities
-function _afp_compute_r!(R::Matrix{T}, S::DenseMatrix{T}, A::Matrix{T}) where T
+function _afp_compute_r!(R::Matrix{T}, S::AbstractMatrix{T}, A::Matrix{T}) where T
     n = size(S, 1)
 
     I1 = Vector{Int}(undef, n)  # I1[i] is the column index of the maximum element in (A+S)[i,:]
@@ -245,7 +245,7 @@ function _afp_extract_exemplars(A::Matrix, R::Matrix)
 end
 
 # get assignments
-function _afp_get_assignments(S::DenseMatrix, exemplars::Vector{Int})
+function _afp_get_assignments(S::AbstractMatrix, exemplars::Vector{Int})
     n = size(S, 1)
     k = length(exemplars)
     Se = S[:, exemplars]

--- a/src/dbscan.jl
+++ b/src/dbscan.jl
@@ -108,7 +108,7 @@ function _dbs_region_query(D::AbstractMatrix{T}, p::Int, eps::T) where T<:Real
     return nbs::Vector{Int}
 end
 
-function _dbs_expand_cluster!(D::AbstractMatrix{T},           # distance matrix
+function _dbs_expand_cluster!(D::AbstractMatrix{T},        # distance matrix
                               k::Int,                      # the index of current cluster
                               p::Int,                      # the index of seeding point
                               nbs::Vector{Int},            # eps-neighborhood of p

--- a/src/dbscan.jl
+++ b/src/dbscan.jl
@@ -43,7 +43,7 @@ end
 ## main algorithm
 
 """
-    dbscan(D::DenseMatrix, eps::Real, minpts::Int) -> DbscanResult
+    dbscan(D::AbstractMatrix, eps::Real, minpts::Int) -> DbscanResult
 
 Perform DBSCAN algorithm using the distance matrix `D`.
 
@@ -54,7 +54,7 @@ The following options control which points would be considered
   - `minpts::Int`: the minimum number of neighboring points (including itself)
      to qualify a point as a density point.
 """
-function dbscan(D::DenseMatrix{T}, eps::Real, minpts::Int) where T<:Real
+function dbscan(D::AbstractMatrix{T}, eps::Real, minpts::Int) where T<:Real
     # check arguments
     n = size(D, 1)
     size(D, 2) == n || throw(ArgumentError("D must be a square matrix ($(size(D)) given)."))
@@ -66,7 +66,7 @@ function dbscan(D::DenseMatrix{T}, eps::Real, minpts::Int) where T<:Real
     _dbscan(D, convert(T, eps), minpts, 1:n)
 end
 
-function _dbscan(D::DenseMatrix{T}, eps::T, minpts::Int, visitseq::AbstractVector{Int}) where T<:Real
+function _dbscan(D::AbstractMatrix{T}, eps::T, minpts::Int, visitseq::AbstractVector{Int}) where T<:Real
     n = size(D, 1)
 
     # prepare
@@ -96,7 +96,7 @@ end
 
 ## key steps
 
-function _dbs_region_query(D::DenseMatrix{T}, p::Int, eps::T) where T<:Real
+function _dbs_region_query(D::AbstractMatrix{T}, p::Int, eps::T) where T<:Real
     n = size(D,1)
     nbs = Int[]
     dists = view(D,:,p)
@@ -108,7 +108,7 @@ function _dbs_region_query(D::DenseMatrix{T}, p::Int, eps::T) where T<:Real
     return nbs::Vector{Int}
 end
 
-function _dbs_expand_cluster!(D::DenseMatrix{T},           # distance matrix
+function _dbs_expand_cluster!(D::AbstractMatrix{T},           # distance matrix
                               k::Int,                      # the index of current cluster
                               p::Int,                      # the index of seeding point
                               nbs::Vector{Int},            # eps-neighborhood of p

--- a/src/kmedoids.jl
+++ b/src/kmedoids.jl
@@ -38,7 +38,7 @@ const _kmed_default_tol = 1.0e-8
 const _kmed_default_display = :none
 
 """
-    kmedoids(dist::DenseMatrix, k::Integer; ...) -> KmedoidsResult
+    kmedoids(dist::AbstractMatrix, k::Integer; ...) -> KmedoidsResult
 
 Perform K-medoids clustering of ``n`` points into `k` clusters,
 given the `dist` matrix (``n×n``, `dist[i, j]` is the distance
@@ -59,7 +59,7 @@ The function implements a *K-means style* algorithm instead of *PAM*
 iterations, but was shown to produce worse (10-20% higher total costs) results
 (see e.g. [Schubert & Rousseeuw (2019)](@ref kmedoid_refs)).
 """
-function kmedoids(dist::DenseMatrix{T}, k::Integer;
+function kmedoids(dist::AbstractMatrix{T}, k::Integer;
                   init=_kmed_default_init,
                   maxiter::Integer=_kmed_default_maxiter,
                   tol::Real=_kmed_default_tol,
@@ -79,7 +79,7 @@ function kmedoids(dist::DenseMatrix{T}, k::Integer;
 end
 
 """
-    kmedoids!(dist::DenseMatrix, medoids::Vector{Int};
+    kmedoids!(dist::AbstractMatrix, medoids::Vector{Int};
               [kwargs...]) -> KmedoidsResult
 
 Update the current cluster `medoids` using the `dist` matrix.
@@ -89,7 +89,7 @@ as `medoids` argument.
 
 See [`kmedoids`](@ref) for the description of optional `kwargs`.
 """
-function kmedoids!(dist::DenseMatrix{T}, medoids::Vector{Int};
+function kmedoids!(dist::AbstractMatrix{T}, medoids::Vector{Int};
                    maxiter::Integer=_kmed_default_maxiter,
                    tol::Real=_kmed_default_tol,
                    display::Symbol=_kmed_default_display) where T<:Real
@@ -110,7 +110,7 @@ end
 #### core algorithm
 
 function _kmedoids!(medoids::Vector{Int},      # initialized medoids
-                    dist::DenseMatrix{T},      # distance matrix
+                    dist::AbstractMatrix{T},      # distance matrix
                     maxiter::Int,              # maximum number of iterations
                     tol::Real,                 # tolerable change of objective
                     displevel::Int) where T<:Real            # level of display
@@ -182,7 +182,7 @@ end
 
 
 # update assignments and related quantities
-function _kmed_update_assignments!(dist::DenseMatrix{T},         # in: (n, n)
+function _kmed_update_assignments!(dist::AbstractMatrix{T},         # in: (n, n)
                                    medoids::AbstractVector{Int}, # in: (k,)
                                    assignments::Vector{Int},     # out: (n,)
                                    groups::Vector{Vector{Int}},  # out: (k,)
@@ -233,7 +233,7 @@ end
 # find medoid for a given group
 #
 # TODO: faster way without creating temporary arrays
-function _find_medoid(dist::DenseMatrix, grp::Vector{Int})
+function _find_medoid(dist::AbstractMatrix, grp::Vector{Int})
     @assert !isempty(grp)
     p = argmin(sum(dist[grp, grp], dims=2))
     return grp[p]::Int

--- a/src/kmedoids.jl
+++ b/src/kmedoids.jl
@@ -110,7 +110,7 @@ end
 #### core algorithm
 
 function _kmedoids!(medoids::Vector{Int},      # initialized medoids
-                    dist::AbstractMatrix{T},      # distance matrix
+                    dist::AbstractMatrix{T},   # distance matrix
                     maxiter::Int,              # maximum number of iterations
                     tol::Real,                 # tolerable change of objective
                     displevel::Int) where T<:Real            # level of display
@@ -182,7 +182,7 @@ end
 
 
 # update assignments and related quantities
-function _kmed_update_assignments!(dist::AbstractMatrix{T},         # in: (n, n)
+function _kmed_update_assignments!(dist::AbstractMatrix{T},      # in: (n, n)
                                    medoids::AbstractVector{Int}, # in: (k,)
                                    assignments::Vector{Int},     # out: (n,)
                                    groups::Vector{Vector{Int}},  # out: (k,)

--- a/test/affprop.jl
+++ b/test/affprop.jl
@@ -6,6 +6,7 @@ using Clustering
 using LinearAlgebra
 using Random
 using Statistics
+include("test_helpers.jl")
 
 @testset "affinityprop() (affinity propagation)" begin
     @testset "Argument checks" begin
@@ -47,11 +48,10 @@ using Statistics
     end
 
     @testset "Support for arrays other than Matrix{T}" begin
-        R2 = affinityprop(@view S[:,:])  # run on complete subarray
-        @test R2.assignments == R.assignments
-
-        R3 = affinityprop(Symmetric(S))  # run on complete subarray
-        @test R3.assignments == R.assignments
+        @testset "$(typeof(M))" for M in equivalent_matrices(S)
+            R2 = affinityprop(M)
+            @test R2.assignments == R.assignments
+        end
     end
 
     #= compare with python result

--- a/test/affprop.jl
+++ b/test/affprop.jl
@@ -46,6 +46,11 @@ using Statistics
         @test R.counts[i] == count(==(i), R.assignments)
     end
 
+    @testset "Ensure works on nonbasic array type (SubArray)" begin
+        RR = affinityprop(@view S[:,:])  # run on complete subarray
+        @test RR.assignments == R.assignments
+    end
+
     #= compare with python result
     the reference assignments were computed using python sklearn:
     ```julia

--- a/test/affprop.jl
+++ b/test/affprop.jl
@@ -46,7 +46,7 @@ using Statistics
         @test R.counts[i] == count(==(i), R.assignments)
     end
 
-    @testset "Ensure works on nonbasic array type" begin
+    @testset "Support for arrays other than Matrix{T}" begin
         R2 = affinityprop(@view S[:,:])  # run on complete subarray
         @test R2.assignments == R.assignments
 

--- a/test/affprop.jl
+++ b/test/affprop.jl
@@ -46,9 +46,12 @@ using Statistics
         @test R.counts[i] == count(==(i), R.assignments)
     end
 
-    @testset "Ensure works on nonbasic array type (SubArray)" begin
-        RR = affinityprop(@view S[:,:])  # run on complete subarray
-        @test RR.assignments == R.assignments
+    @testset "Ensure works on nonbasic array type" begin
+        R2 = affinityprop(@view S[:,:])  # run on complete subarray
+        @test R2.assignments == R.assignments
+
+        R3 = affinityprop(Symmetric(S))  # run on complete subarray
+        @test R3.assignments == R.assignments
     end
 
     #= compare with python result

--- a/test/dbscan.jl
+++ b/test/dbscan.jl
@@ -36,6 +36,11 @@ for c = 1:k
 end
 @test all(R.counts .>= 180)
 
+@testset "Ensure works on nonbasic array type (SubArray)" begin
+    RR = dbscan(@view(D[:,:]), 1.0, 10)  # run on complete subarray
+    @test RR.assignments == R.assignments
+end
+
 @testset "normal points" begin
     Random.seed!(0)
     p0 = randn(3, 1000)
@@ -64,6 +69,5 @@ end
         @test length(clusters) == 3
     end
 end
-
 
 end

--- a/test/dbscan.jl
+++ b/test/dbscan.jl
@@ -1,6 +1,7 @@
 using Test
 using Clustering
 using Distances
+include("test_helpers.jl")
 
 @testset "dbscan() (DBSCAN clustering)" begin
 
@@ -37,11 +38,10 @@ end
 @test all(R.counts .>= 180)
 
 @testset "Support for arrays other than Matrix{T}" begin
-    R2 = dbscan(@view(D[:,:]), 1.0, 10)  # run on complete subarray
-    @test R2.assignments == R.assignments
-
-    R3 = dbscan(Symmetric(D), 1.0, 10)  # run on complete subarray
-    @test R3.assignments == R.assignments
+    @testset "$(typeof(M))" for M in equivalent_matrices(D)
+        R2 = dbscan(M, 1.0, 10)  # run on complete subarray
+        @test R2.assignments == R.assignments
+    end
 end
 
 @testset "normal points" begin

--- a/test/dbscan.jl
+++ b/test/dbscan.jl
@@ -36,9 +36,12 @@ for c = 1:k
 end
 @test all(R.counts .>= 180)
 
-@testset "Ensure works on nonbasic array type (SubArray)" begin
-    RR = dbscan(@view(D[:,:]), 1.0, 10)  # run on complete subarray
-    @test RR.assignments == R.assignments
+@testset "Ensure works on nonbasic array type" begin
+    R2 = dbscan(@view(D[:,:]), 1.0, 10)  # run on complete subarray
+    @test R2.assignments == R.assignments
+
+    R3 = dbscan(Symmetric(D), 1.0, 10)  # run on complete subarray
+    @test R3.assignments == R.assignments
 end
 
 @testset "normal points" begin

--- a/test/dbscan.jl
+++ b/test/dbscan.jl
@@ -36,7 +36,7 @@ for c = 1:k
 end
 @test all(R.counts .>= 180)
 
-@testset "Ensure works on nonbasic array type" begin
+@testset "Support for arrays other than Matrix{T}" begin
     R2 = dbscan(@view(D[:,:]), 1.0, 10)  # run on complete subarray
     @test R2.assignments == R.assignments
 

--- a/test/kmedoids.jl
+++ b/test/kmedoids.jl
@@ -27,6 +27,7 @@ X = rand(d, n)
 dist = pairwise(SqEuclidean(), X, dims=2)
 @assert size(dist) == (n, n)
 
+Random.seed!(34568)  # reset seed again to known state
 R = kmedoids(dist, k)
 @test isa(R, KmedoidsResult)
 @test nclusters(R) == k
@@ -38,6 +39,12 @@ R = kmedoids(dist, k)
 @test R.costs == dist[LinearIndices((n, n))[CartesianIndex.(R.medoids[R.assignments], 1:n)]]
 @test isapprox(sum(R.costs), R.totalcost)
 @test R.converged
+
+@testset "Ensure works on nonbasic array type (SubArray)" begin
+    Random.seed!(34568)  # restore seed as kmedoids is not determantistic
+    RR = kmedoids(@view(dist[:,:]), k)  # run on complete subarray
+    @test RR.assignments == R.assignments
+end
 
 # k=1 and k=n cases
 x = pairwise(SqEuclidean(), [1 2 3; .1 .2 .3; 4 5.6 7], dims=2)

--- a/test/kmedoids.jl
+++ b/test/kmedoids.jl
@@ -40,10 +40,14 @@ R = kmedoids(dist, k)
 @test isapprox(sum(R.costs), R.totalcost)
 @test R.converged
 
-@testset "Ensure works on nonbasic array type (SubArray)" begin
+@testset "Ensure works on nonbasic array type" begin
     Random.seed!(34568)  # restore seed as kmedoids is not determantistic
-    RR = kmedoids(@view(dist[:,:]), k)  # run on complete subarray
-    @test RR.assignments == R.assignments
+    R2 = kmedoids(@view(dist[:,:]), k)  # run on complete subarray
+    @test R2.assignments == R.assignments
+
+    Random.seed!(34568)  # restore seed as kmedoids is not determantistic
+    R3 = kmedoids(Symmetric(dist), k)  # run on complete subarray
+    @test R3.assignments == R.assignments
 end
 
 # k=1 and k=n cases

--- a/test/kmedoids.jl
+++ b/test/kmedoids.jl
@@ -1,7 +1,7 @@
 using Test
-
 using Distances
 using Clustering
+include("test_helpers.jl")
 
 @testset "kmedoids() (k-medoids)" begin
 
@@ -41,13 +41,11 @@ R = kmedoids(dist, k)
 @test R.converged
 
 @testset "Support for arrays other than Matrix{T}" begin
-    Random.seed!(34568)  # restore seed as kmedoids is not determantistic
-    R2 = kmedoids(@view(dist[:,:]), k)  # run on complete subarray
-    @test R2.assignments == R.assignments
-
-    Random.seed!(34568)  # restore seed as kmedoids is not determantistic
-    R3 = kmedoids(Symmetric(dist), k)  # run on complete subarray
-    @test R3.assignments == R.assignments
+    @testset "$(typeof(M))" for M in equivalent_matrices(dist)
+        Random.seed!(34568)  # restore seed as kmedoids is not determantistic
+        R2 = kmedoids(M, k)
+        @test R2.assignments == R.assignments
+    end
 end
 
 # k=1 and k=n cases

--- a/test/kmedoids.jl
+++ b/test/kmedoids.jl
@@ -40,7 +40,7 @@ R = kmedoids(dist, k)
 @test isapprox(sum(R.costs), R.totalcost)
 @test R.converged
 
-@testset "Ensure works on nonbasic array type" begin
+@testset "Support for arrays other than Matrix{T}" begin
     Random.seed!(34568)  # restore seed as kmedoids is not determantistic
     R2 = kmedoids(@view(dist[:,:]), k)  # run on complete subarray
     @test R2.assignments == R.assignments

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -1,0 +1,24 @@
+using LinearAlgebra
+using SparseArrays
+
+"""
+    equivalent_matrices(x::AbstractMatrix)
+
+Returns a collection of matrixes that are equal to the input `x`, but of a different type.
+Useful for testing if things still work on different types of matrix.
+"""
+function equivalent_matrices(x::AbstractMatrix)
+    mats = [
+        Base.PermutedDimsArray(x, (1,2)),  # identity permutation
+        view(x, :, :),
+        view(x, collect.(axes(x))...),  # breaks `strides`
+        sparse(x),
+    ]
+    if issymmetric(x)
+        append!(mats, [
+            Symmetric(x),
+            Transpose(x),
+        ])
+    end
+    return mats
+end


### PR DESCRIPTION
Affprop, DBScan and K-Mediods were dispatching on `DenseMatrix`.
This is a uncomfortable compromise as a great many matrix types, especially wrapper types, subtype `AbstractMatrix`.
(This makes sense the wrapper type doesn't know what it is wrapping).

I would be kind a surprised if any of the algorithms didn't work on structured or sparse matrixes.
Albeit with reduced performance and possibly large allocations.
But if they don't work for a particular type then that will throw its own error -- we don't need to  `MethodError` right at the start.

Examples of `AbstractMatrix` this should now support `Transpose`,`PermuteDims` and `SubArray`, `Symmetric` (rather makes sense for distances). And things from packages like `NamedDimsArray` and `StaticArray`.

I have added tests with the distance matrixes as `SubArray` and `Symmetric`, to make sure it works.
 