### PR TITLE
tests: increase vmeasure test iterations to 200

### DIFF
--- a/test/vmeasure.jl
+++ b/test/vmeasure.jl
@@ -32,6 +32,7 @@ using Clustering
     end
 
     @testset "comparing 2 k-means clusterings" begin
+        Random.seed!(34568) # set random seed for RNG used by kmeans()
         rng = StableRNG(34568)
         m = 3
         n = 1000
@@ -42,7 +43,7 @@ using Clustering
             x = rand(rng, m, n)
             vmeasure(kmeans(x, k; maxiter=50),
                      kmeans(x, k; maxiter=50))
-        end for _ in 1:100])
+        end for _ in 1:200])
         @test 0.5 < v < 1.0
         @test v ≈ 0.75 atol=1e-2 # FIXME why 0.75?
     end


### PR DESCRIPTION
Since #211 we are using StableRNGs to make the tests more stable, but some methods (e.g. `kmeans()`) use random numbers in their implementation.
Try to fix vmeasure test by initializing Julia RNG and increasing the number of iterations.
