### PR TITLE
Added pair counting fmeasure metric

### DIFF
--- a/src/Clustering.jl
+++ b/src/Clustering.jl
@@ -64,7 +64,10 @@ module Clustering
     Hclust, hclust, cutree,
 
     # MCL
-    mcl, MCLResult
+    mcl, MCLResult,
+
+    #fmeasure
+    pair_precision, fmeasure, pair_recall
 
     ## source files
 
@@ -84,6 +87,7 @@ module Clustering
     include("varinfo.jl")
     include("vmeasure.jl")
     include("mutualinfo.jl")
+    include("fmeasure.jl")
 
     include("hclust.jl")
 

--- a/src/fmeasure.jl
+++ b/src/fmeasure.jl
@@ -1,0 +1,83 @@
+"""
+    _pair_confusion_matrix(a,b) -> NTuple{4, Int64}
+
+Compute the similarities between two clusterings by considering all pairs of samples.
+
+Returns (TruePositive,FalsePositive,FalseNegative,TrueNegative)
+
+"""
+function _pair_confusion_matrix(a,b)
+    c = counts(a, b)
+    n = length(a)
+    n_k = sum(c,dims=1)[:]
+    n_c = sum(c,dims=2)[:]
+    n_sum = sum(c.*c)
+    tp = n_sum-n
+    fp = sum(c*n_k)-n_sum
+    fn = sum(c'*n_c)-n_sum
+    tn = n^2-fp-fn-n_sum 
+    return tp,fp,fn,tn
+end
+
+
+
+"""
+    pair_precision(a, b) -> Float64
+
+Compute the pair counting precision between two clustering of the same data points.
+
+`a` and `b` can be either [`ClusteringResult`](@ref) instances or
+assignments vectors (`AbstractVector{<:Integer}`).
+
+Returns the value of the pair counting precision.
+
+# References
+> Pfitzner, Darius, Richard Leibbrandt, and David Powers. (2009).
+> *Characterization and evaluation of similarity measures for pairs of clusterings.*
+> Knowledge and Information Systems: 361-394.
+"""
+function pair_precision(a, b)
+    tp,fp,fn,tn = _pair_confusion_matrix(a,b)
+    return tp/(tp+fp)
+end
+
+"""
+    pair_recall(a, b) -> Float64
+
+Compute the pair counting recall between two clustering of the same data points.
+
+`a` and `b` can be either [`ClusteringResult`](@ref) instances or
+assignments vectors (`AbstractVector{<:Integer}`).
+
+Returns the value of the pair counting recall.
+
+# References
+> Pfitzner, Darius, Richard Leibbrandt, and David Powers. (2009).
+> *Characterization and evaluation of similarity measures for pairs of clusterings.*
+> Knowledge and Information Systems: 361-394.
+"""
+function pair_recall(a, b)
+    tp,fp,fn,tn = _pair_confusion_matrix(a,b)
+    return tp/(tp+fn)
+end
+
+"""
+    fmeasure(a, b) -> Float64
+
+Compute the pair counting fmeasure between two clustering of the same data points.
+
+`a` and `b` can be either [`ClusteringResult`](@ref) instances or
+assignments vectors (`AbstractVector{<:Integer}`).
+
+Returns the value of the pair counting recall.
+
+# References
+> Pfitzner, Darius, Richard Leibbrandt, and David Powers. (2009).
+> *Characterization and evaluation of similarity measures for pairs of clusterings.*
+> Knowledge and Information Systems: 361-394.
+"""
+function fmeasure(a, b)
+    p = pair_precision(a,b)
+    r = pair_recall(a,b)
+    return (2*p*r)/(p+r)
+end

--- a/test/fmeasure.jl
+++ b/test/fmeasure.jl
@@ -1,0 +1,20 @@
+using Test
+using Clustering
+
+@testset "fmeasure()" begin
+
+
+    a1 = [1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3]
+    a2 = [1, 1, 1, 1, 1, 2, 3, 3, 1, 2, 2, 2, 2, 2, 3, 3, 3]
+    @test fmeasure(a1, a2) ≈ 0.47 atol=1.0e-2
+    @test pair_precision(a1, a2) ≈ 0.5 atol=1.0e-2
+    @test pair_recall(a1, a2) ≈ 0.45 atol=1.0e-2
+
+
+    a1 = [1, 1, 1, 1, 1, 3, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 1, 2]
+    a2 = [1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4]
+    @test fmeasure(a1, a2) ≈ 0.529 atol=1.0e-2
+    @test pair_precision(a1, a2) ≈ 0.6 atol=1.0e-2
+    @test pair_recall(a1, a2) ≈ 0.47 atol=1.0e-2
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,8 @@ tests = ["seeding",
          "hclust",
          "mcl",
          "vmeasure",
-         "mutualinfo"]
+         "mutualinfo",
+         "fmeasure"]
 
 println("Runing tests:")
 for t in tests


### PR DESCRIPTION
I often use this metric, I think it's worth having.

refs:
https://nlp.stanford.edu/IR-book/html/htmledition/evaluation-of-clustering-1.html

https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.214.7233&rep=rep1&type=pdf

Included also is precision and recall for clustering, I was not sure about the proper name (e.g. precision is already in use by Julia base).

The _pair_confusion_matrix is translated from sklearn's https://github.com/scikit-learn/scikit-learn/blob/2beed55847ee70d363bdbfe14ee4401438fba057/sklearn/metrics/cluster/_supervised.py#L154

there is a small duplication with the rand index, which also require this matrix, but as I did not want to modify it to use my new function.