### PR TITLE
Disambiguate use of "pairwise" function

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -9,7 +9,7 @@ SUITE["hclust"] = BenchmarkGroup()
 
 function random_distance_matrix(n::Integer, m::Integer=10, dist::PreMetric=Euclidean())
     pts = rand(m, n)
-    return pairwise(dist, pts, dims=2)
+    return Distances.pairwise(dist, pts, dims=2)
 end
 
 function hclust_benchmark(n::Integer, m::Integer=10, dist::PreMetric=Euclidean())

--- a/src/fuzzycmeans.jl
+++ b/src/fuzzycmeans.jl
@@ -32,7 +32,7 @@ wcounts(R::FuzzyCMeansResult) = dropdims(sum(R.weights, dims=2), dims=2)
 function update_weights!(weights, data, centers, fuzziness, dist_metric)
     pow = 2.0/(fuzziness-1)
     nrows, ncols = size(weights)
-    dists = pairwise(dist_metric, data, centers, dims=2)
+    dists = Distances.pairwise(dist_metric, data, centers, dims=2)
     for i in 1:nrows
         for j in 1:ncols
             den = 0.0

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -135,7 +135,7 @@ function _kmeans!(X::AbstractMatrix{<:Real},                # in: data matrix (d
     counts = Vector{Int}(undef, k)
 
     # compute pairwise distances, preassign costs and cluster weights
-    dmat = pairwise(distance, centers, X, dims=2)
+    dmat = Distances.pairwise(distance, centers, X, dims=2)
     WC = (weights === nothing) ? Int : eltype(weights)
     wcounts = Vector{WC}(undef, k)
     D = typeof(one(eltype(dmat)) * one(WC))

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -166,11 +166,11 @@ function _kmeans!(X::AbstractMatrix{<:Real},                # in: data matrix (d
         end
 
         if t == 1 || num_affected > 0.75 * k
-            pairwise!(dmat, distance, centers, X, dims=2)
+            Distances.pairwise!(dmat, distance, centers, X, dims=2)
         else
             # if only a small subset is affected, only compute for that subset
             affected_inds = findall(to_update)
-            pairwise!(view(dmat, affected_inds, :), distance,
+            Distances.pairwise!(view(dmat, affected_inds, :), distance,
                       view(centers, :, affected_inds), X, dims=2)
         end
 

--- a/src/seeding.jl
+++ b/src/seeding.jl
@@ -256,4 +256,4 @@ end
 
 initseeds!(iseeds::IntegerVector, alg::KmCentralityAlg, X::AbstractMatrix{<:Real},
            metric::PreMetric = SqEuclidean()) =
-    initseeds_by_costs!(iseeds, alg, pairwise(metric, X, dims=2))
+    initseeds_by_costs!(iseeds, alg, Distances.pairwise(metric, X, dims=2))

--- a/test/affprop.jl
+++ b/test/affprop.jl
@@ -27,7 +27,7 @@ include("test_helpers.jl")
     d = 10
     n = 500
     x = rand(d, n)
-    S = -pairwise(Euclidean(), x, x, dims=2)
+    S = -Distances.pairwise(Euclidean(), x, x, dims=2)
 
     # set diagonal value to median value
     S = S - diagm(0 => diag(S)) + median(S)*I

--- a/test/dbscan.jl
+++ b/test/dbscan.jl
@@ -22,7 +22,7 @@ X3 = randn(2, 200) .+ [5., 0.]
 X = hcat(X1, X2, X3)
 n = size(X,2)
 
-D = pairwise(Euclidean(), X, dims=2)
+D = Distances.pairwise(Euclidean(), X, dims=2)
 
 R = dbscan(D, 1.0, 10)
 @test isa(R, DbscanResult)

--- a/test/hclust.jl
+++ b/test/hclust.jl
@@ -155,7 +155,7 @@ end
         end
     end
 
-    dm = pairwise(Euclidean(), mat, dims=2)
+    dm = Distances.pairwise(Euclidean(), mat, dims=2)
 
     hcl_r = hclust(dm, linkage=:average)
     hcl_barjoseph = hclust(dm, linkage=:average, branchorder=:barjoseph)

--- a/test/kmeans.jl
+++ b/test/kmeans.jl
@@ -20,7 +20,7 @@ end
 Distances.result_type(::MySqEuclidean, ::Type{T}, ::Type{T}) where T <: Number = T
 
 (dist::MySqEuclidean)(a::AbstractMatrix, b::AbstractMatrix) =
-    pairwise!(similar(a, size(a, 2), size(b, 2)))
+    Distances.pairwise!(similar(a, size(a, 2), size(b, 2)))
 
 @testset "kmeans() (k-means)" begin
 

--- a/test/kmedoids.jl
+++ b/test/kmedoids.jl
@@ -9,7 +9,7 @@ include("test_helpers.jl")
     Random.seed!(34568)
     @test_throws ArgumentError kmedoids(randn(2, 3), 1)
     @test_throws ArgumentError kmedoids(randn(2, 3), 4)
-    dist = inv.(max.(pairwise(Euclidean(), randn(2, 3), dims=2), 0.1))
+    dist = inv.(max.(Distances.pairwise(Euclidean(), randn(2, 3), dims=2), 0.1))
     @test kmedoids(dist, 2) isa KmedoidsResult
     @test_throws ArgumentError kmedoids(dist, 2, display=:mylog)
     for disp in keys(Clustering.DisplayLevels)
@@ -24,7 +24,7 @@ n = 200
 k = 10
 
 X = rand(d, n)
-dist = pairwise(SqEuclidean(), X, dims=2)
+dist = Distances.pairwise(SqEuclidean(), X, dims=2)
 @assert size(dist) == (n, n)
 
 Random.seed!(34568)  # reset seed again to known state
@@ -49,7 +49,7 @@ R = kmedoids(dist, k)
 end
 
 # k=1 and k=n cases
-x = pairwise(SqEuclidean(), [1 2 3; .1 .2 .3; 4 5.6 7], dims=2)
+x = Distances.pairwise(SqEuclidean(), [1 2 3; .1 .2 .3; 4 5.6 7], dims=2)
 kmed1 = kmedoids(x, 1)
 @test nclusters(kmed1) == 1
 @test assignments(kmed1) == [1, 1, 1]
@@ -67,7 +67,7 @@ kmed3 = kmedoids(x, 3)
 #
 
 X = reshape(map(Float64, [1, 6, 2, 3, 7, 21, 8, 20, 22]), 1, 9)
-dist = pairwise(SqEuclidean(), X, dims=2)
+dist = Distances.pairwise(SqEuclidean(), X, dims=2)
 
 R = kmedoids!(dist, [1, 2, 6])
 @test isa(R, KmedoidsResult)

--- a/test/mcl.jl
+++ b/test/mcl.jl
@@ -8,7 +8,7 @@ using Clustering
 @testset "Argument Checks" begin
     Random.seed!(34568)
     @test_throws DimensionMismatch mcl(zeros(Float64, 4, 3)) # nonsquare
-    adj = inv.(max.(pairwise(Euclidean(), randn(2, 3), dims=2), 0.1))
+    adj = inv.(max.(Distances.pairwise(Euclidean(), randn(2, 3), dims=2), 0.1))
     @test_throws ArgumentError mcl(zeros(Float64, 3, 3), display=:mylog)
     for disp in keys(Clustering.DisplayLevels)
         @test mcl(zeros(Float64, 3, 3), display=disp) isa MCLResult

--- a/test/seeding.jl
+++ b/test/seeding.jl
@@ -13,7 +13,7 @@ Random.seed!(34568)
 alldistinct(x::Vector{Int}) = (length(Set(x)) == length(x))
 
 function min_interdist(X::AbstractMatrix)
-    dists = Distances.pairwise(SqEuclidean(), X, dims=2)
+    dists = pairwise(SqEuclidean(), X, dims=2)
     n = size(X, 2)
     r = Inf
     for i = 1:n, j = 1:n
@@ -29,7 +29,7 @@ d = 3
 n = 100
 k = 5
 X = rand(d, n)
-C = Distances.pairwise(SqEuclidean(), X, dims=2)
+C = pairwise(SqEuclidean(), X, dims=2)
 
 Xt = copy(transpose(X))
 Ct = copy(transpose(C))

--- a/test/seeding.jl
+++ b/test/seeding.jl
@@ -13,7 +13,7 @@ Random.seed!(34568)
 alldistinct(x::Vector{Int}) = (length(Set(x)) == length(x))
 
 function min_interdist(X::AbstractMatrix)
-    dists = pairwise(SqEuclidean(), X, dims=2)
+    dists = Distances.pairwise(SqEuclidean(), X, dims=2)
     n = size(X, 2)
     r = Inf
     for i = 1:n, j = 1:n
@@ -29,7 +29,7 @@ d = 3
 n = 100
 k = 5
 X = rand(d, n)
-C = pairwise(SqEuclidean(), X, dims=2)
+C = Distances.pairwise(SqEuclidean(), X, dims=2)
 
 Xt = copy(transpose(X))
 Ct = copy(transpose(C))


### PR DESCRIPTION
Hi, 
I am working on a package that depends on clustering.jl and got the following error while trying to perform kmeans clustering.
![image](https://user-images.githubusercontent.com/21320417/146388776-0378ed08-54bf-4d62-855d-60cb57ea5160.png)
In this PR, I just add `Distances.` in front of all the `pairwise`s, so that it becomes clear. 