### PR TITLE
Stop using unexported Base.permute!!

### DIFF
--- a/src/hclust.jl
+++ b/src/hclust.jl
@@ -504,9 +504,9 @@ function orderbranches_r!(hmer::HclustMerges)
             ml[i], mr[i] = mr[i], ml[i]
         end
     end
-    permute!(ml, o)
-    permute!(mr, o)
-    Base.permute!!(hmer.heights, o)
+    copyto!(ml, ml[o])
+    copyto!(mr, mr[o])
+    copyto!(hmer.heights, hmer.heights[o])
     return hmer
 end
 

--- a/src/hclust.jl
+++ b/src/hclust.jl
@@ -504,9 +504,9 @@ function orderbranches_r!(hmer::HclustMerges)
             ml[i], mr[i] = mr[i], ml[i]
         end
     end
-    copyto!(ml, ml[o])
-    copyto!(mr, mr[o])
-    copyto!(hmer.heights, hmer.heights[o])
+    permute!(ml, o)
+    permute!(mr, o)
+    permute!(hmer.heights, o)
     return hmer
 end
 


### PR DESCRIPTION
This PR may increase performance in some cases and should pretty much never pose much of a regression. Perhaps more importantly, it drops a dependency on an undocumented internal method of Julia that may be removed in 1.10 because internals are not subject to SymVer.

In 1.9.0, Julia's `permute!` method got a bit more efficient. These benchmarks compare use of `permute!` to `permute!!`

```julia
julia> using BenchmarkTools, Random, Plots

julia> x = 2 .^ (3:26);

julia> GC.gc(); y!! = [(hmer_heights = rand(Int, n); o = randperm(n); @elapsed(Base.permute!!(hmer_heights, o))) for n in x];

julia> GC.gc(); y! = [(hmer_heights = rand(Int, n); o = randperm(n); @elapsed(permute!(hmer_heights, o))) for n in x];

julia> plot(x, y! ./ x, label="permute!"); plot!(x, y!! ./ x, label="permute!!", xlabel="length(hmer_heights)", ylabel="seconds/element", xscale=:log10, yscale=:log10)
```
<img width="591" alt="Screenshot 2023-05-14 at 5 22 17 PM" src="https://github.com/JuliaStats/Clustering.jl/assets/60898866/b364ff40-7d98-4610-89a5-593d9082791a">

In the case of the usage in this package, in cases where `permute!!` is faster (small inputs or old versions of Julia) this PR may result in a minor performance regression, but never more than 33% because there are already two calls to `permute!` in this spot. In cases where `permute!!` is slower, there is not really a cap on how much of an improvement this PR can be. For large inputs on modern versions of Julia, this could easily be a 3x or more improvement because of the poor cache locality properties of `permute!!`.

(I rewrote this post with the release of 1.9.0)
