### PR TITLE
Remove test for a method from StatsBase

### DIFF
--- a/test/counts.jl
+++ b/test/counts.jl
@@ -13,8 +13,6 @@ end
 
 @testset "counts() (contingency matrix)" begin
 
-# StatsBase's counts() doesn't allow empty inputs
-@test_throws ArgumentError counts(Int[], Int[])
 # Clustering's counts()
 @test counts(SimpleCluRes(Int[]), Int[]) == Matrix{Int}(undef, 0, 0)
 @test_throws DimensionMismatch counts(SimpleCluRes([1]), Int[])


### PR DESCRIPTION
The code is testing that `counts` with two empty input arrays produces an `ArgumentError`, which is failing because it actually produces a `MethodError` from a Base function deeper in the call stack. The method in question here is defined in StatsBase, not in this package, so it's unclear why this package is testing it to begin with.