### PR TITLE
Update dbscan.jl to support Arrow.Table files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
 version = "0.14.3"
 
 [deps]
+Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"

--- a/src/dbscan.jl
+++ b/src/dbscan.jl
@@ -70,7 +70,7 @@ function dbscan(D::Arrow.Table, ϵ::Real, minpts::Int; T = Base.Float64)
     # check arguments    
     eps > 0 || throw(ArgumentError("ϵ must be a positive value ($eps given)."))
     minpts >= 1 || throw(ArgumentError("minpts must be positive integer ($minpts given)."))
-
+    n = length(keys(D))
     # invoke core algorithm
     _dbscan(D, convert(T, eps), minpts, 1:n)
 end

--- a/src/dbscan.jl
+++ b/src/dbscan.jl
@@ -6,7 +6,7 @@
 #       A density-based algorithm for discovering clusters
 #       in large spatial databases with noise. 1996.
 #
-
+import Arrow
 """
     DbscanResult <: ClusteringResult
 

--- a/src/dbscan.jl
+++ b/src/dbscan.jl
@@ -66,6 +66,15 @@ function dbscan(D::AbstractMatrix{T}, eps::Real, minpts::Int) where T<:Real
     _dbscan(D, convert(T, eps), minpts, 1:n)
 end
 
+function dbscan(D::Arrow.Table, ϵ::Real, minpts::Int; T = Base.Float64)
+    # check arguments    
+    eps > 0 || throw(ArgumentError("ϵ must be a positive value ($eps given)."))
+    minpts >= 1 || throw(ArgumentError("minpts must be positive integer ($minpts given)."))
+
+    # invoke core algorithm
+    _dbscan(D, convert(T, eps), minpts, 1:n)
+end
+
 function _dbscan(D::AbstractMatrix{T}, eps::T, minpts::Int, visitseq::AbstractVector{Int}) where T<:Real
     n = size(D, 1)
 
@@ -94,6 +103,36 @@ function _dbscan(D::AbstractMatrix{T}, eps::T, minpts::Int, visitseq::AbstractVe
     return DbscanResult(seeds, assignments, counts)
 end
 
+#Arrow.Table support
+function _dbscan(D::Arrow.Table, eps::T, minpts::Int, visitseq::AbstractVector{Int}) where T<:Real
+    n = length(keys(D))
+
+    # prepare
+    seeds = Int[]
+    counts = Int[]
+    assignments = zeros(Int, n)
+    visited = zeros(Bool, n)
+    k = 0
+
+    # main loop
+    for p in visitseq
+        if assignments[p] == 0 && !visited[p]
+            visited[p] = true
+            nbs = _dbs_region_query(D, p, eps)
+            if length(nbs) >= minpts
+                k += 1
+                cnt = _dbs_expand_cluster!(D, k, p, nbs, eps, minpts, assignments, visited)
+                push!(seeds, p)
+                push!(counts, cnt)
+            end
+        end
+    end
+
+    # make output
+    return DbscanResult(seeds, assignments, counts)
+end
+
+
 ## key steps
 
 function _dbs_region_query(D::AbstractMatrix{T}, p::Int, eps::T) where T<:Real
@@ -107,6 +146,20 @@ function _dbs_region_query(D::AbstractMatrix{T}, p::Int, eps::T) where T<:Real
     end
     return nbs::Vector{Int}
 end
+
+# Arrow.Table support
+function _dbs_region_query(D::Arrow.Table, p::Int, eps::T) where T<:Real
+    n = length(keys(D))
+    nbs = Int[]
+    dists = D[p]
+    for i = 1:n
+        @inbounds if dists[i] < eps
+            push!(nbs, i)
+        end
+    end
+    return nbs::Vector{Int}
+end
+
 
 function _dbs_expand_cluster!(D::AbstractMatrix{T},        # distance matrix
                               k::Int,                      # the index of current cluster
@@ -138,6 +191,40 @@ function _dbs_expand_cluster!(D::AbstractMatrix{T},        # distance matrix
     end
     return cnt
 end
+
+# Arrow.Table support
+function _dbs_expand_cluster!(D::Arrow.Table,              # distance matrix
+                              k::Int,                      # the index of current cluster
+                              p::Int,                      # the index of seeding point
+                              nbs::Vector{Int},            # eps-neighborhood of p
+                              eps::T,                        # radius of neighborhood
+                              minpts::Int,                 # minimum number of neighbors of a density point
+                              assignments::Vector{Int},    # assignment vector
+                              visited::Vector{Bool}) where T<:Real       # visited indicators
+    assignments[p] = k
+    cnt = 1
+    while !isempty(nbs)
+        q = popfirst!(nbs)
+        if !visited[q]
+            visited[q] = true
+            qnbs = _dbs_region_query(D, q, eps)
+            if length(qnbs) >= minpts
+                for x in qnbs
+                    if assignments[x] == 0
+                        push!(nbs, x)
+                    end
+                end
+            end
+        end
+        if assignments[q] == 0
+            assignments[q] = k
+            cnt += 1
+        end
+    end
+    return cnt
+end
+
+
 
 """
     dbscan(points::AbstractMatrix, radius::Real,


### PR DESCRIPTION
Dear all, 
I recently tried to perform clustering with DBSCAN algorithm. Unfortunately, my distance matrix and the raw data matrix are too large to fit into memory (> 100 GB). Hence, I usually save the data in batches using the Julia Package Arrow.jl, since it allows to memory map huge the data and fast indexing. Hence, I changed the functions for DBSCAN clustering to be compatible with the Arrow.Table data format. I thought that the support of the Arrow.Table format might interest also other people working with huge datasets. 

If you are interested in adding this functionality, I can also update the documentation or add the support to other clustering algortihms. 

Best wishes. 