### PR TITLE
feat: method for clustering new data kmeans added

### DIFF
--- a/src/Clustering.jl
+++ b/src/Clustering.jl
@@ -29,7 +29,7 @@ module Clustering
     kmpp, kmpp_by_costs,
 
     # kmeans
-    kmeans, kmeans!, KmeansResult,
+    kmeans, kmeans!, KmeansResult, get_cluster_assignments,
 
     # kmedoids
     kmedoids, kmedoids!, KmedoidsResult,

--- a/test/kmeans.jl
+++ b/test/kmeans.jl
@@ -204,4 +204,11 @@ end
     end
 end
 
+@testset "get cluster assigments" begin
+    X = rand(5, 100)
+    R = kmeans(X, 10; maxiter=200)
+    clusters_from_get_cluster_assignments = get_cluster_assignments(X, R);
+    @test R.assignments == clusters_from_get_cluster_assignments
+end
+
 end


### PR DESCRIPTION

Some applications require training a Kmeans with a few datapoints but then using the fitted model with a large amount of data. Currently there is no method in the package that, given a fitted model and an array, find the cluster labels for the new data.