### PR TITLE
Distributed silhouette

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -29,3 +29,21 @@ SUITE["cutree"] = BenchmarkGroup()
 for (n, k) in ((10, 3), (100, 10), (1000, 100), (10000, 1000))
     SUITE["cutree"][(n,k)] = @benchmarkable cutree(hclu, k=$k) setup=(D=random_distance_matrix($n, 5); hclu=hclust(D, linkage=:single))
 end
+
+SUITE["silhouette"] = BenchmarkGroup()
+
+precalc_val(pre_calculate) = pre_calculate == "without_precalculation" ? false : true
+function silhouette_benchmark(a, X, nclusters)
+    res = BenchmarkGroup()
+    for pre_calculate in ("without_precalculation", "with_precalculation")
+        res[pre_calculate] = @benchmarkable silhouettes(SqEuclidean(), $a, $X; nclusters=$nclusters, pre_calculate=precalc_val($pre_calculate))
+    end
+    return res
+end
+
+for (label, n) in (("n=100", 100), ("n=1,000", 1000), ("n=10,000", 10000), ("n=20,000", 20000))
+    nclusters = 10
+    dims = 3
+    X = rand(dims, n); a = rand(1:nclusters, n)
+    SUITE["silhouette"][label] = silhouette_benchmark(a, X, nclusters)
+end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -32,11 +32,10 @@ end
 
 SUITE["silhouette"] = BenchmarkGroup()
 
-precalc_val(pre_calculate) = pre_calculate == "without_precalculation" ? false : true
 function silhouette_benchmark(a, X, nclusters)
     res = BenchmarkGroup()
-    for pre_calculate in ("without_precalculation", "with_precalculation")
-        res[pre_calculate] = @benchmarkable silhouettes(SqEuclidean(), $a, $X; nclusters=$nclusters, pre_calculate=precalc_val($pre_calculate))
+    for method in (:classic, :cached)
+        res[string(method)] = @benchmarkable silhouettes($a, $X; metric=SqEuclidean(), nclusters=$nclusters, method=Symbol($method))
     end
     return res
 end

--- a/src/Clustering.jl
+++ b/src/Clustering.jl
@@ -83,6 +83,7 @@ module Clustering
     include("fuzzycmeans.jl")
 
     include("counts.jl")
+    include("cluster_distances.jl")
     include("silhouette.jl")
     include("randindex.jl")
     include("varinfo.jl")

--- a/src/Clustering.jl
+++ b/src/Clustering.jl
@@ -47,7 +47,7 @@ module Clustering
     counts, # reexport StatsBase.counts
 
     # silhouette
-    silhouettes,
+    silhouettes, SilhouettesDistsPrecompute, silhouettes_precompute_batch!,
 
     # varinfo
     varinfo,

--- a/src/Clustering.jl
+++ b/src/Clustering.jl
@@ -47,7 +47,7 @@ module Clustering
     counts, # reexport StatsBase.counts
 
     # silhouette
-    silhouettes, SilhouettesDistsPrecompute, silhouettes_precompute_batch!,
+    silhouettes, SqEuclideanPrecomputedSilhouettes, silhouettes_precompute_batch!,
 
     # varinfo
     varinfo,

--- a/src/Clustering.jl
+++ b/src/Clustering.jl
@@ -47,7 +47,7 @@ module Clustering
     counts, # reexport StatsBase.counts
 
     # silhouette
-    silhouettes, SqEuclideanPrecomputedSilhouettes, silhouettes_precompute_batch!,
+    silhouettes, SqEuclideanPrecomputedSilhouettes, precompute_silhouettes,
 
     # varinfo
     varinfo,

--- a/src/Clustering.jl
+++ b/src/Clustering.jl
@@ -47,7 +47,7 @@ module Clustering
     counts, # reexport StatsBase.counts
 
     # silhouette
-    silhouettes, PrecomputeSilhouettes, silhouettes_cache,
+    silhouettes,
 
     # varinfo
     varinfo,

--- a/src/Clustering.jl
+++ b/src/Clustering.jl
@@ -47,7 +47,7 @@ module Clustering
     counts, # reexport StatsBase.counts
 
     # silhouette
-    silhouettes, SqEuclideanPrecomputedSilhouettes, precompute_silhouettes,
+    silhouettes, SqEuclideanPrecomputedSilhouettes, silhouettes_cache,
 
     # varinfo
     varinfo,

--- a/src/Clustering.jl
+++ b/src/Clustering.jl
@@ -47,7 +47,7 @@ module Clustering
     counts, # reexport StatsBase.counts
 
     # silhouette
-    silhouettes, SqEuclideanPrecomputedSilhouettes, silhouettes_cache,
+    silhouettes, PrecomputeSilhouettes, silhouettes_cache,
 
     # varinfo
     varinfo,

--- a/src/cluster_distances.jl
+++ b/src/cluster_distances.jl
@@ -1,0 +1,226 @@
+"""
+Base type for efficient computation of average(mean) distances
+from the cluster centers to a given point.
+
+The descendant types should implement the following methods:
+  * `update!(dists, assignments, points)`: update the internal
+    state of `dists` with point coordinates and their assignments to the clusters
+  * `sumdistances(dists, points, indices)`: compute the sum of
+    distances from all `dists` clusters to `points`
+"""
+abstract type ClusterDistances{T} end
+
+# create empty ClusterDistances object for a given metric
+# and update it with a given clustering
+# if batch_size is specified, the updates are done in point batches of given size
+function ClusterDistances(metric::SemiMetric,
+                 assignments::AbstractVector{<:Integer},
+                 points::AbstractMatrix{<:Real},
+                 batch_size::Union{Integer, Nothing} = nothing)
+    update!(ClusterDistances(eltype(points), metric, length(assignments), size(points, 1),
+                             maximum(assignments)),
+            assignments, points, batch_size)
+end
+
+ClusterDistances(metric, R::ClusteringResult, args...) =
+    ClusterDistances(metric, assignments(R), args...)
+
+# fallback implementations of ClusteringDistances methods
+
+cluster_sizes(dists::ClusterDistances) = dists.cluster_sizes
+nclusters(dists::ClusterDistances) = length(cluster_sizes(dists))
+
+update!(dists::ClusterDistances,
+        assignments::AbstractVector, points::AbstractMatrix) =
+    error("update!(dists::$(typeof(dists))) not implemented")
+
+sumdistances(dists::ClusterDistances,
+             points::Union{AbstractMatrix, Nothing},
+             indices::Union{AbstractVector{<:Integer}, Nothing}) =
+    error("sumdistances(dists::$(typeof(dists))) not implemented")
+
+# average distances from each cluster to each point, nclusters×n matrix
+function meandistances(dists::ClusterDistances,
+                       assignments::AbstractVector{<:Integer},
+                       points::Union{AbstractMatrix, Nothing},
+                       indices::AbstractVector{<:Integer})
+    @assert length(assignments) == length(indices)
+    (points === nothing) || @assert(size(points, 2) == length(indices))
+    clu_to_pt = sumdistances(dists, points, indices)
+    clu_sizes = cluster_sizes(dists)
+    @assert length(assignments) == length(indices)
+    @assert size(clu_to_pt) == (length(clu_sizes), length(assignments))
+
+    # normalize distances by cluster sizes
+    @inbounds for j in eachindex(assignments)
+        for (i, c) in enumerate(clu_sizes)
+            if i == assignments[j]
+                c -= 1
+            end
+            if c == 0
+                clu_to_pt[i,j] = 0
+            else
+                clu_to_pt[i,j] /= c
+            end
+        end
+    end
+    return clu_to_pt
+end
+
+# wrapper for ClusteringResult
+update!(dists::ClusterDistances, R::ClusteringResult, args...) =
+    update!(dists, assignments(R), args...)
+
+# batch-update silhouette dists (splitting the points into chunks of batch_size size)
+function update!(dists::ClusterDistances,
+                 assignments::AbstractVector{<:Integer}, points::AbstractMatrix{<:Real},
+                 batch_size::Union{Integer, Nothing})
+    n = size(points, 2)
+    ((batch_size === nothing) || (n <= batch_size)) &&
+        return update!(dists, assignments, points)
+
+    for batch_start in 1:batch_size:n
+        batch_ixs = batch_start:min(batch_start + batch_size - 1, n)
+        update!(dists, view(assignments, batch_ixs), view(points, :, batch_ixs))
+    end
+    return dists
+end
+
+# generic ClusterDistances implementation for an arbitrary metric M
+# if M is Nothing, point_dists is an arbitrary matrix of point distances
+struct SimpleClusterDistances{M, T} <: ClusterDistances{T}
+    metric::M
+    cluster_sizes::Vector{Int}
+    assignments::Vector{Int}
+    point_dists::Matrix{T}
+
+    SimpleClusterDistances(::Type{T}, metric::M,
+                           npoints::Integer, nclusters::Integer) where {M<:Union{SemiMetric, Nothing}, T<:Real} =
+        new{M, T}(metric, zeros(Int, nclusters), Vector{Int}(),
+                  Matrix{T}(undef, npoints, npoints))
+
+    # reuse given points matrix
+    function SimpleClusterDistances(
+        metric::Nothing,
+        assignments::AbstractVector{<:Integer},
+        point_dists::AbstractMatrix{T}
+    ) where T<:Real
+        n = length(assignments)
+        size(point_dists) == (n, n) || throw(DimensionMismatch("assignments length ($n) does not match distances matrix size ($(size(point_dists)))"))
+        issymmetric(point_dists) || throw(ArgumentError("point distances matrix must be symmetric"))
+        clu_sizes = zeros(Int, maximum(assignments))
+        @inbounds for cluster in assignments
+            clu_sizes[cluster] += 1
+        end
+        new{Nothing, T}(metric, clu_sizes, assignments, point_dists)
+    end
+end
+
+# fallback ClusterDistances constructor
+ClusterDistances(::Type{T}, metric::Union{SemiMetric, Nothing},
+                 npoints::Union{Integer, Nothing}, dims::Integer, nclusters::Integer) where T<:Real =
+    SimpleClusterDistances(T, metric, npoints, nclusters)
+
+# when metric is nothing, points is the matrix of distances
+function ClusterDistances(metric::Nothing,
+                          assignments::AbstractVector{<:Integer},
+                          points::AbstractMatrix,
+                          batch_size::Union{Integer, Nothing} = nothing)
+    (batch_size === nothing) || (size(points, 2) > batch_size) ||
+        error("batch-updates of distance matrix-based ClusterDistances not supported")
+    SimpleClusterDistances(metric, assignments, points)
+end
+
+function update!(dists::SimpleClusterDistances{M},
+                 assignments::AbstractVector{<:Integer},
+                 points::AbstractMatrix{<:Real}) where M
+    @assert length(assignments) == size(points, 2)
+    check_assignments(assignments, nclusters(dists))
+    append!(dists.assignments, assignments)
+    n = size(dists.point_dists, 1)
+    length(dists.assignments) == n ||
+        error("$(typeof(dists)) does not support batch updates: $(length(assignments)) points given, $n expected")
+    @inbounds for cluster in assignments
+        dists.cluster_sizes[cluster] += 1
+    end
+
+    if M === Nothing
+        size(point_dists) == (n, n) ||
+            throw(DimensionMismatch("points should be a point-to-point distances matrix of ($n, $n) size, $(size(points)) given"))
+        copy!(dists.point_dists, point_dists)
+    else
+        # metric-based SimpleClusterDistances does not support batched updates
+        size(points, 2) == n ||
+            throw(DimensionMismatch("points should be a point coordinates matrix with $n columns, $(size(points, 2)) found"))
+        pairwise!(dists.metric, dists.point_dists, points, dims=2)
+    end
+
+    return dists
+end
+
+# this function returns matrix r nclusters x n, such that
+# r[i, j] is the sum of distances from all i-th cluster points to the point indices[j]
+function sumdistances(dists::SimpleClusterDistances,
+                      points::Union{AbstractMatrix, Nothing}, # unused as distances are already in point_dists
+                      indices::AbstractVector{<:Integer})
+    T = eltype(dists.point_dists)
+    n = length(dists.assignments)
+    S = typeof((one(T)+one(T))/2)
+    r = zeros(S, nclusters(dists), n)
+    @inbounds for (jj, j) in enumerate(indices)
+        for i = 1:j-1
+            r[dists.assignments[i], jj] += dists.point_dists[i,j]
+        end
+        for i = j+1:n
+            r[dists.assignments[i], jj] += dists.point_dists[i,j]
+        end
+    end
+    return r
+end
+
+# uses the method from "Distributed Silhouette Algorithm: Evaluating Clustering on Big Data"
+# https://arxiv.org/abs/2303.14102
+# for SqEuclidean point distances
+struct SqEuclideanClusterDistances{T} <: ClusterDistances{T}
+    cluster_sizes::Vector{Int} # [nclusters]
+    Y::Matrix{T} # [dims, nclusters], the first moments of each cluster (sum of point coords)
+    Ψ::Vector{T} # [nclusters], the second moments of each cluster (sum of point coord squares)
+
+    SqEuclideanClusterDistances(::Type{T}, npoints::Union{Integer, Nothing}, dims::Integer,
+                                nclusters::Integer) where T<:Real =
+        new{T}(zeros(Int, nclusters), zeros(T, dims, nclusters), zeros(T, nclusters))
+end
+
+ClusterDistances(::Type{T}, metric::SqEuclidean, npoints::Union{Integer, Nothing},
+                 dims::Integer, nclusters::Integer) where T<:Real =
+    SqEuclideanClusterDistances(T, npoints, dims, nclusters)
+
+function update!(dists::SqEuclideanClusterDistances,
+                 assignments::AbstractVector{<:Integer},
+                 points::AbstractMatrix{<:Real})
+    # x dims are [D,N]
+    d, n = size(points)
+    k = length(cluster_sizes(dists))
+    check_assignments(assignments, k)
+    n == length(assignments) || throw(DimensionMismatch("points count ($n) does not match assignments length $(length(assignments)))"))
+    d == size(dists.Y, 1) || throw(DimensionMismatch("points dims ($(size(points, 1))) do no must match ClusterDistances dims ($(size(dists.Y, 1)))"))
+    # precompute moments and update counts
+    @inbounds for (i, cluster) in enumerate(assignments)
+        point = view(points, :, i) # switch to eachslice() once Julia-1.0 support is dropped
+        dists.cluster_sizes[cluster] += 1
+        dists.Y[:, cluster] .+= point
+        dists.Ψ[cluster] += sum(abs2, point)
+    end
+    return dists
+end
+
+# sum distances from each cluster to each point in `points`, [nclusters, n]
+function sumdistances(dists::SqEuclideanClusterDistances,
+                      points::AbstractMatrix,
+                      indices::AbstractVector{<:Integer})
+    @assert size(points, 2) == length(indices)
+    point_norms = sum(abs2, points; dims=1) # [1,n]
+    return dists.cluster_sizes .* point_norms .+
+        reshape(dists.Ψ, nclusters(dists), 1) .-
+        2 * (transpose(dists.Y) * points)
+end

--- a/src/silhouette.jl
+++ b/src/silhouette.jl
@@ -105,7 +105,6 @@ function sil_aggregate_distances_normalized(assignments::AbstractVector{<:Intege
                                         dists::AbstractMatrix{T}) where T<:Real
     n = length(assignments)
     nclusters = length(counts)
-    nclusters >= 2 || throw(ArgumentError("silhouettes() not defined for the degenerated clustering with a single cluster."))
     check_assignments(assignments, nclusters)
     sum(counts) == n || throw(ArgumentError("Mismatch between assignments ($n) and counts (sum(counts)=$(sum(counts)))."))
     size(dists) == (n, n) || throw(DimensionMismatch("The size of a distance matrix ($(size(dists))) doesn't match the length of assignment vector ($n)."))
@@ -118,8 +117,7 @@ end
 
 function sil_aggregate_distances_normalized_streaming(x::AbstractMatrix{T}, assignments::AbstractVector{Int}, pre::SqEuclideanPrecomputedSilhouettes{T}) where T <: Real
     nclusters = pre.nclusters
-    n = size(x, 2)
-    nclusters >= 2 || throw(ArgumentError("silhouettes() not defined for the degenerated clustering with a single cluster."))
+    check_assignments(assignments, nclusters)
     size(x, 1) == size(pre.Y, 1) || throw(ArgumentError("input features dimension does not match with precomputation on dimension 1"))
 
     # compute average distance from each cluster to each point --> r

--- a/src/silhouette.jl
+++ b/src/silhouette.jl
@@ -217,7 +217,7 @@ function silhouettes(assignments::AbstractVector{<:Integer}, points:: AbstractMa
                      method::Symbol = :default,
                      nclusters=maximum(assignments))
 
-    @assert in(method, [:default, :classis, :cached]) "method key argument must be one of :default, :classic or :cached"
+    @assert in(method, [:default, :classic, :cached]) "method key argument must be one of :default, :classic or :cached"
     metric === nothing && @assert(iszero(diag(points)) && issymmetric(points), "silhouettes(): metric not provided, yet points matrix does not seem to be a distances matrix - symmetric and zero on the diagonal.")
     
     if method == :default

--- a/src/silhouette.jl
+++ b/src/silhouette.jl
@@ -1,5 +1,45 @@
 # Silhouette
 
+mutable struct SilhouettesDistsPrecompute{T}
+    k::Int
+    d::Int
+    counts::Matrix{Int} #[k, 1]
+    Ψ::Matrix{T} #[k, 1]
+    Y::Matrix{T} #[d, k]
+end
+
+SilhouettesDistsPrecompute(k::Int, d::Int, ::Type{T}) where T<:Real= SilhouettesDistsPrecompute{T}(k, d, 
+                                                                                      zeros(Int, k, 1),
+                                                                                      zeros(T, k, 1), 
+                                                                                      zeros(T, d, k))
+
+                                                                                      # this does the same as sil_aggregate_dists, but uses the method in "Distributed Silhouette Algorithm: Evaluating Clustering on Big Data"
+# https://arxiv.org/abs/2303.14102
+# this implementation uses the square
+function silhouettes_precompute_batch!(k::Int, a::AbstractVector{Int}, x::AbstractMatrix{T}, pre::SilhouettesDistsPrecompute{T}) where T<:Real
+    # x dims are [D,N]
+    d, n = size(x)
+    all(1 .<= a .<= k) || throw(ArgumentError("Bad assignments: should be in 1:$k range."))
+    d == pre.d || throw(ArgumentError("Bad data: x[1]=$d must match pre.d=$(pre.d)."))
+    # update counts
+    for (val, cnt) in countmap(a)
+        pre.counts[val] += cnt
+    end
+    @assert n == length(a) "data matrix dimensions must be (..., $(length(a))) and got $(size(x))"
+    ξ = sum(x.^2; dims=1) # [1,n]
+    # precompute vectors
+    for kk in 1:k
+        @inbounds pre.Y[:, kk] += sum((reshape(a, 1, n) .== kk) .* x; dims=2)
+        @inbounds pre.Ψ[kk] += sum((reshape(a, 1, n) .== kk) .* ξ)
+    end
+end
+
+function silhouettes_precompute_batch!(R::ClusteringResult, 
+                                              x::AbstractMatrix{T}, 
+                                              pre::SilhouettesDistsPrecompute{T}) where T<:Real
+    silhouettes_precompute_batch!(nclusters(R), assignments(R), x, pre)
+end
+
 # this function returns r of size (k, n), such that
 # r[i, j] is the sum of distances of all points from cluster i to point j
 #
@@ -18,33 +58,27 @@ function sil_aggregate_dists(k::Int, a::AbstractVector{Int}, dists::AbstractMatr
     return r
 end
 
+function normalize_aggregate_dists!(r, assignments, counts, k, n)
+    # from sum to average
+    @inbounds for j = 1:n
+        for i = 1:k
+            c = copy(counts[i])
+            if i == assignments[j]
+                c -= 1
+            end
+            if c == 0
+                r[i,j] = 0
+            else
+                r[i,j] /= c
+            end
+        end
+    end
+    return r
+end
 
-"""
-    silhouettes(assignments::AbstractVector, [counts,] dists) -> Vector{Float64}
-    silhouettes(clustering::ClusteringResult, dists) -> Vector{Float64}
-
-Compute *silhouette* values for individual points w.r.t. given clustering.
-
-Returns the ``n``-length vector of silhouette values for each individual point.
-
-# Arguments
- - `assignments::AbstractVector{Int}`: the vector of point assignments
-   (cluster indices)
- - `counts::AbstractVector{Int}`: the optional vector of cluster sizes (how many
-   points assigned to each cluster; should match `assignments`)
- - `clustering::ClusteringResult`: the output of some clustering method
- - `dists::AbstractMatrix`: ``n×n`` matrix of pairwise distances between
-   the points
-
-# References
-> Peter J. Rousseeuw (1987). *Silhouettes: a Graphical Aid to the
-> Interpretation and Validation of Cluster Analysis*. Computational and
-> Applied Mathematics. 20: 53–65.
-"""
-function silhouettes(assignments::AbstractVector{<:Integer},
-                     counts::AbstractVector{<:Integer},
-                     dists::AbstractMatrix{T}) where T<:Real
-
+function sil_aggregate_dists_normalized(assignments::AbstractVector{<:Integer},
+                                        counts::AbstractVector{<:Integer},
+                                        dists::AbstractMatrix{T}) where T<:Real
     n = length(assignments)
     k = length(counts)
     k >= 2 || throw(ArgumentError("silhouettes() not defined for the degenerated clustering with a single cluster."))
@@ -56,27 +90,31 @@ function silhouettes(assignments::AbstractVector{<:Integer},
 
     # compute average distance from each cluster to each point --> r
     r = sil_aggregate_dists(k, assignments, dists)
-    # from sum to average
-    @inbounds for j = 1:n
-        for i = 1:k
-            c = counts[i]
-            if i == assignments[j]
-                c -= 1
-            end
-            if c == 0
-                r[i,j] = 0
-            else
-                r[i,j] /= c
-            end
-        end
-    end
+    r = normalize_aggregate_dists!(r, assignments, counts, k, n)
+    return r
+end
 
+function sil_aggregate_dists_normalized_streaming(x::AbstractMatrix{T}, assignments::AbstractVector{Int}, pre::SilhouettesDistsPrecompute{T}) where T <: Real
+    k = pre.k
+    n = size(x, 2)
+    k >= 2 || throw(ArgumentError("silhouettes() not defined for the degenerated clustering with a single cluster."))
+    size(x, 1) == size(pre.Y, 1) || throw(ArgumentError("input features dimension does not match with precomputation on dimension 1"))
+
+    # compute average distance from each cluster to each point --> r
+    ξx = sum(x.^2; dims=1) # [1,n]
+    r = pre.counts .* ξx .+ pre.Ψ .- 2 .* transpose(pre.Y) * x # r is [k, n]
+    r = normalize_aggregate_dists!(r, assignments, pre.counts, k, n)
+    return r
+end
+
+function silhouettes_given_dist(r::Matrix{T}, assignments::AbstractVector{Int}, counts::Vector{Int}) where {T}
+    n = length(assignments)
     # compute a and b
     # a: average distance w.r.t. the assigned cluster
     # b: the minimum average distance w.r.t. other cluster
     a = similar(r, n)
     b = similar(r, n)
-
+    k = length(counts)
     for j = 1:n
         l = assignments[j]
         a[j] = r[l, j]
@@ -105,6 +143,43 @@ function silhouettes(assignments::AbstractVector{<:Integer},
         end
     end
     return sil
+end
+
+
+"""
+    silhouettes(assignments::AbstractVector, [counts,] dists) -> Vector{Float64}
+    silhouettes(clustering::ClusteringResult, dists) -> Vector{Float64}
+    silhouettes(x::AbstractMatrix, assignments::AbstractVector, pre::SilhouettesDistsPrecompute) -> Vector{Float64}
+
+Compute *silhouette* values for individual points w.r.t. given clustering.
+
+Returns the ``n``-length vector of silhouette values for each individual point.
+
+# Arguments
+ - `assignments::AbstractVector{Int}`: the vector of point assignments
+   (cluster indices)
+ - `counts::AbstractVector{Int}`: the optional vector of cluster sizes (how many
+   points assigned to each cluster; should match `assignments`)
+ - `clustering::ClusteringResult`: the output of some clustering method
+ - `dists::AbstractMatrix`: ``n×n`` matrix of pairwise distances between
+   the points
+
+# References
+> Peter J. Rousseeuw (1987). *Silhouettes: a Graphical Aid to the
+> Interpretation and Validation of Cluster Analysis*. Computational and
+> Applied Mathematics. 20: 53–65.
+"""
+function silhouettes(assignments::AbstractVector{<:Integer},
+                     counts::AbstractVector{<:Integer},
+                     dists::AbstractMatrix{T}) where T<:Real
+
+    r = sil_aggregate_dists_normalized(assignments, counts, dists)
+    return silhouettes_given_dist(r, assignments, counts)
+end
+
+function silhouettes(x::AbstractMatrix{T}, assignments::AbstractVector{<:Integer}, pre::SilhouettesDistsPrecompute{T}) where T<:Real
+    r = sil_aggregate_dists_normalized_streaming(x, assignments, pre)
+    return silhouettes_given_dist(r, assignments, reshape(pre.counts, :))
 end
 
 silhouettes(R::ClusteringResult, dists::AbstractMatrix) =

--- a/src/silhouette.jl
+++ b/src/silhouette.jl
@@ -18,33 +18,34 @@ struct SqEuclideanPrecomputeSilhouettes{T} <: PrecomputeSilhouettes
                                                                                                   zeros(T, dims, nclusters))
 end
 
+"""
+silhouettes_cache(t::Type, metric::Union{Metric, SemiMetric}, nclusters::Int, dims::Int)
+Return an PrecomputeSilhouettes object which can be used to process large amounts of data to get silhouette scores.
+This implementation only supports square Euclidean distances at present.
+See also [`silhouettes`](@ref) [`SqEuclideanPrecomputeSilhouettes`](@ref)
+
+# Examples:
+```julia-repl
+Julia> using Distances
+Julia> nclusters=10; dims=3; bs=100; n=10000;
+Julia> pre = silhouettes_cache(Float32, SqEuclidean(), nclusters, dims);
+Julia> x = reshape(collect(Float32, 1:30000), dims, n); # direct computation is impractical on such a big dataset
+Julia> a = reshape(repeat(collect(1:nclusters),trunc(Int, n/nclusters)), n);
+Julia> batches_x = eachslice(reshape(x, dims, trunc(Int, n/bs), bs); dims=3); batches_a = eachslice(reshape(a, trunc(Int, n/bs), bs); dims=2);
+Julia> @time [pre(xx, aa) for (xx, aa) in zip(batches_x, batches_a)]; # precompute vectors on big data
+0.502363 seconds (956.08 k allocations: 65.143 MiB, 2.23% gc time, 99.85% compilation time)
+Julia> @time sil = vcat([silhouettes(xx, aa, pre) for (xx, aa) in zip(batches_x, batches_a)]...); # calculate silhouette scores in batched fashion
+0.046788 seconds (54.28 k allocations: 4.346 MiB, 98.45% compilation time)
+Julia> size(sil)
+(10000,)
+```
+"""
 silhouettes_cache(::Type, metric::Union{Metric, SemiMetric}, nclusters, dims) = error("precomputed_silhouettes() for metric $(typeof(metric)) is not implemented")
 silhouettes_cache(t::Type, metric::SqEuclidean, nclusters::Int, dims::Int) = SqEuclideanPrecomputeSilhouettes(t, nclusters, dims)
 
 # this does the same as sil_aggregate_dists, but uses the method in "Distributed Silhouette Algorithm: Evaluating Clustering on Big Data"
 # https://arxiv.org/abs/2303.14102
 # this implementation uses the SqEuclidean distance only
-"""
-precompute_silhouettes(pre::SqEuclideanPrecomputeSilhouettes{T}, assignments::AbstractVector{Int}, x::AbstractMatrix{T}) where T<:Real
-Include a batch of data and cluster assignments (x,assignments) in the precomputations for silhouettes.
-This implementation supports only square Euclidean distances at present.
-See also [`silhouettes`](@ref) [`SqEuclideanPrecomputeSilhouettes`](@ref)
-
-# Examples:
-```julia-repl
-Julia> nclusters=10; d=3; bs=100; n=10000;
-Julia> pre = SqEuclideanPrecomputeSilhouettes(Float32, nclusters, d);
-Julia> x = reshape(collect(Float32, 1:30000), 3, n); # direct computation is impractical on such a big dataset
-Julia> a = reshape(repeat(collect(1:nclusters),trunc(Int, n/nclusters)), n);
-Julia> batches_x = eachslice(reshape(x, 3, trunc(Int, n/bs), bs); dims=3); batches_a = eachslice(reshape(a, trunc(Int, n/bs), bs); dims=2);
-Julia> @time [precompute_silhouettes(pre, aa, xx) for (xx, aa) in zip(batches_x, batches_a)]; # precompute vectors on big data
-0.838358 seconds (2.06 M allocations: 141.495 MiB, 4.24% gc time, 99.00% compilation time)
-Julia> @time sil = vcat([silhouettes(xx, aa, pre) for (xx, aa) in zip(batches_x, batches_a)]); # calculate silhouette scores in batched fashion
-0.049759 seconds (53.78 nclusters allocations: 4.440 MiB, 98.54% compilation time)
-Julia> size(sil)
-(10000,)
-```
-"""
 function precompute_silhouettes(pre::SqEuclideanPrecomputeSilhouettes{T}, x::AbstractMatrix{T}, assignments::AbstractVector{Int}) where T<:Real
     # x dims are [D,N]
     d, n = size(x)

--- a/src/silhouette.jl
+++ b/src/silhouette.jl
@@ -1,163 +1,26 @@
 # Silhouette
-"""
-Base type for efficient computation of [`silhouettes`](@ref) clustering metric.
-"""
-abstract type SilhouettesCache{T} end
-
-struct SqEuclideanSilhouettesCache{T} <: SilhouettesCache{T}
-    nclusters::Int
-    dims::Int
-    counts::Vector{Int} #[nclusters, 1]
-    Ψ::Vector{T} #[nclusters], This represents the second moments of each cluster
-    Y::Matrix{T} #[dims, nclusters], This represents the first moments of each cluster
-    """
-    SqEuclideanSilhouettesCache(::Type{T}, nclusters::Int, dims::Int)
-    Precomputations container for [`precompute_silhouettes`](@ref).
-    See also [`silhouettes`](@ref), [`precompute_silhouettes`](@ref)
-    """
-    SqEuclideanSilhouettesCache(::Type{T}, nclusters::Int, dims::Int) where T<:Real= new{T}(nclusters, dims, 
-                                                                                                  zeros(Int, nclusters),
-                                                                                                  zeros(T, nclusters), 
-                                                                                                  zeros(T, dims, nclusters))
-end
-
-"""
-silhouettes_cache(t::Type, metric::Union{Metric, SemiMetric}, nclusters::Int, dims::Int)
-Return an SilhouettesCache object which can be used to process large amounts of data to get silhouette scores.
-This implementation only supports square Euclidean distances at present.
-See also [`silhouettes`](@ref) [`SqEuclideanSilhouettesCache`](@ref)
-
-# Examples:
-```julia-repl
-Julia> using Distances
-Julia> nclusters=10; dims=3; bs=100; n=10000;
-Julia> pre = silhouettes_cache(Float32, SqEuclidean(), nclusters, dims);
-Julia> x = reshape(collect(Float32, 1:30000), dims, n); # direct computation is impractical on such a big dataset
-Julia> a = reshape(repeat(collect(1:nclusters),trunc(Int, n/nclusters)), n);
-Julia> batches_x = eachslice(reshape(x, dims, trunc(Int, n/bs), bs); dims=3); batches_a = eachslice(reshape(a, trunc(Int, n/bs), bs); dims=2);
-Julia> @time [pre(xx, aa) for (xx, aa) in zip(batches_x, batches_a)]; # precompute vectors on big data
-0.502363 seconds (956.08 k allocations: 65.143 MiB, 2.23% gc time, 99.85% compilation time)
-Julia> @time sil = vcat([silhouettes(xx, aa, pre) for (xx, aa) in zip(batches_x, batches_a)]...); # calculate silhouette scores in batched fashion
-0.046788 seconds (54.28 k allocations: 4.346 MiB, 98.45% compilation time)
-Julia> size(sil)
-(10000,)
-```
-"""
-silhouettes_cache(::Type, metric::Union{Metric, SemiMetric}, nclusters, dims) = error("precomputed_silhouettes() for metric $(typeof(metric)) is not implemented")
-silhouettes_cache(t::Type, metric::SqEuclidean, nclusters::Int, dims::Int)::SilhouettesCache = SqEuclideanSilhouettesCache(t, nclusters, dims)
-
-# this does the same as sil_aggregate_dists, but uses the method in "Distributed Silhouette Algorithm: Evaluating Clustering on Big Data"
-# https://arxiv.org/abs/2303.14102
-# this implementation uses the SqEuclidean distance only
-function precompute_silhouettes(pre::SqEuclideanSilhouettesCache{T}, x::AbstractMatrix{T}, assignments::AbstractVector{Int}) where T<:Real
-    # x dims are [D,N]
-    d, n = size(x)
-    check_assignments(assignments, pre.nclusters)
-    d == pre.dims || throw(ArgumentError("Bad data: x[1]=$d must match pre.d=$(pre.d)."))
-    # update counts
-    for (val, cnt) in countmap(assignments)
-        pre.counts[val] += cnt
-    end
-    @assert n == length(assignments) "data matrix dimensions must be (..., $(length(assignments))) and got $(size(x))"
-    ξ = sum(abs2, x; dims=1) # [1,n]
-    # precompute vectors
-    @inbounds for (i, cluster) in enumerate(assignments)
-        pre.Y[:, cluster] .+= view(x, :, i)
-        pre.Ψ[cluster] += ξ[i]
-    end
-    return pre
-end
-
-precompute_silhouettes(pre::SqEuclideanSilhouettesCache{T}, 
-                       x::AbstractMatrix{T}, R::ClusteringResult) where T<:Real = precompute_silhouettes(pre, x, assignments(R))
-
-
-function (pre::SqEuclideanSilhouettesCache)(x::AbstractMatrix{T}, assignments::Union{AbstractVector{Int}, ClusteringResult}) where T<:Real
-    precompute_silhouettes(pre, x, assignments)
-end
-
-# this function returns r of size (nclusters, n), such that
-# r[i, j] is the sum of distances of all points from cluster i to point j
-#
-function sil_aggregate_dists(nclusters::Int, assignments::AbstractVector{Int}, dists::AbstractMatrix{T}) where T<:Real
-    n = length(assignments)
-    S = typeof((one(T)+one(T))/2)
-    r = zeros(S, nclusters, n)
-    @inbounds for j = 1:n
-        for i = 1:j-1
-            r[assignments[i],j] += dists[i,j]
-        end
-        for i = j+1:n
-            r[assignments[i],j] += dists[i,j]
-        end
-    end
-    return r
-end
-
-function normalize_aggregate_distances!(r, assignments, counts)
-    # from sum to average
-    @assert size(r) == (length(counts), length(assignments)) "silhouettes: cluster_to_point matrix dimensions $(size(r)) do not match assignments and counts - $(((length(counts), length(assignments))))"
-    @inbounds for j in eachindex(assignments)
-        for i in eachindex(counts)
-            c = counts[i]
-            if i == assignments[j]
-                c -= 1
-            end
-            if c == 0
-                r[i,j] = 0
-            else
-                r[i,j] /= c
-            end
-        end
-    end
-    return r
-end
-
-function sil_aggregate_distances_normalized(assignments::AbstractVector{<:Integer},
-                                        counts::AbstractVector{<:Integer},
-                                        dists::AbstractMatrix{T}) where T<:Real
-    n = length(assignments)
-    nclusters = length(counts)
-    check_assignments(assignments, nclusters)
-    sum(counts) == n || throw(ArgumentError("Mismatch between assignments ($n) and counts (sum(counts)=$(sum(counts)))."))
-    size(dists) == (n, n) || throw(DimensionMismatch("The size of a distance matrix ($(size(dists))) doesn't match the length of assignment vector ($n)."))
-
-    # compute average distance from each cluster to each point --> r
-    cluster_to_point = sil_aggregate_dists(nclusters, assignments, dists)
-    cluster_to_point = normalize_aggregate_distances!(cluster_to_point, assignments, counts)
-    return cluster_to_point
-end
-
-function sil_aggregate_distances_normalized_streaming(x::AbstractMatrix{T}, assignments::AbstractVector{Int}, pre::SqEuclideanSilhouettesCache{T}) where T <: Real
-    nclusters = pre.nclusters
-    check_assignments(assignments, nclusters)
-    size(x, 1) == size(pre.Y, 1) || throw(ArgumentError("silhouette: number of input features (dimension 1) used in pre computation was $(size(pre.Y, 1)), got $(size(x, 1))"))
-    size(x, 2) == length(assignments) || throw(ArgumentError("silhouette: number of input points $(size(x, 2)) do not match number of assignments $(length(assignments))"))
-
-    # compute average distance from each cluster to each point --> r
-    ξx = sum(abs2, x; dims=1) # [1,n]
-    cluster_to_point = reshape(pre.counts, :, 1) .* ξx .+ reshape(pre.Ψ, pre.nclusters, 1) .- 2 .* transpose(pre.Y) * x # cluster_to_point is [nclusters, n]
-    cluster_to_point = normalize_aggregate_distances!(cluster_to_point, assignments, pre.counts)
-    return cluster_to_point
-end
 
 # compute silhouette scores for each point given a matrix of cluster-to-point distances
-function silhouette_scores(cluster_to_point::AbstractMatrix{<:Real}, assignments::AbstractVector{Int}, counts::Vector{Int})
+function silhouettes_scores(clu_to_pt::AbstractMatrix{<:Real},
+                            assignments::AbstractVector{<:Integer},
+                            clu_sizes::AbstractVector{<:Integer})
     n = length(assignments)
+    @assert size(clu_to_pt) == (length(clu_sizes), n)
+
     # compute a and b
     # a: average distance w.r.t. the assigned cluster
     # b: the minimum average distance w.r.t. other cluster
-    a = similar(cluster_to_point, n)
-    b = similar(cluster_to_point, n)
-    nclusters = length(counts)
-    for j = 1:n
+    a = similar(clu_to_pt, n)
+    b = similar(clu_to_pt, n)
+    nclusters = length(clu_sizes)
+    for j in 1:n
         l = assignments[j]
-        a[j] = cluster_to_point[l, j]
+        a[j] = clu_to_pt[l, j]
 
         v = typemax(eltype(b))
         @inbounds for i = 1:nclusters
-            counts[i] == 0 && continue # skip empty clusters
-            rij = cluster_to_point[i,j]
+            clu_sizes[i] == 0 && continue # skip empty clusters
+            rij = clu_to_pt[i, j]
             if (i != l) && (rij < v)
                 v = rij
             end
@@ -168,25 +31,48 @@ function silhouette_scores(cluster_to_point::AbstractMatrix{<:Real}, assignments
     # compute silhouette score
     sil = a   # reuse the memory of a for sil
     for j = 1:n
-        if counts[assignments[j]] == 1
+        if clu_sizes[assignments[j]] == 1
             sil[j] = 0
         else
             #If both a[i] and b[i] are equal to 0 or Inf, silhouettes is defined as 0
             @inbounds sil[j] = a[j] < b[j] ? 1 - a[j]/b[j] :
                                a[j] > b[j] ? b[j]/a[j] - 1 :
-                               zero(eltype(cluster_to_point))
+                               zero(eltype(sil))
         end
     end
     return sil
 end
 
+# calculate silhouette scores (single batch)
+silhouettes_batch(dists::ClusterDistances,
+                  assignments::AbstractVector{<:Integer},
+                  points::Union{AbstractMatrix, Nothing},
+                  indices::AbstractVector{<:Integer}) =
+    silhouettes_scores(meandistances(dists, assignments, points, indices),
+                       assignments, cluster_sizes(dists))
+
+# batch-calculate silhouette scores (splitting the points into chunks of batch_size size)
+function silhouettes(dists::ClusterDistances,
+                     assignments::AbstractVector{<:Integer},
+                     points::Union{AbstractMatrix, Nothing},
+                     batch_size::Union{Integer, Nothing} = nothing)
+    n = length(assignments)
+    ((batch_size === nothing) || (n <= batch_size)) &&
+        return silhouettes_batch(dists, assignments, points, eachindex(assignments))
+
+    return mapreduce(vcat, 1:batch_size:n) do batch_start
+        batch_ixs = batch_start:min(batch_start + batch_size - 1, n)
+        # copy points/assignments to speed up matrix and indexing operations
+        silhouettes_batch(dists, assignments[batch_ixs],
+                          points !== nothing ? points[:, batch_ixs] : nothing,
+                          batch_ixs)
+    end
+end
 
 """
-    silhouettes(assignments::AbstractVector, [counts,] dists) -> Vector{Float64}
-    silhouettes(clustering::ClusteringResult, dists) -> Vector{Float64}
-    silhouettes(x::AbstractMatrix, assignments::AbstractVector, pre::SilhouettesCache{T}) -> Vector{Float64}
-    silhouettes(metric::Union{Metric, SemiMetric}, assignments::AbstractVector{<:Integer}, x::AbstractMatrix; 
-                nclusters=maximum(assignments), batch_size=size(x, 2), pre_calculate::Bool=true)
+    silhouettes(assignments::Union{AbstractVector, ClusteringResult}, point_dists::Matrix) -> Vector{Float64}
+    silhouettes(assignments::Union{AbstractVector, ClusteringResult}, points::Matrix;
+                metric::SemiMetric, [batch_size::Integer]) -> Vector{Float64}
 
 Compute *silhouette* values for individual points w.r.t. given clustering.
 
@@ -197,78 +83,28 @@ Returns the ``n``-length vector of silhouette values for each individual point.
    (cluster indices)
  - `points::AbstractMatrix`: if metric is nothing it is an ``n×n`` matrix of pairwise distances between the points,
    otherwise it is an ``d×n`` matrix of `d` dimensional clustered data points.
- - `metric::Union{Metric, SemiMetric, Nothing}`: an instance of Distances Metric object or nothing, 
+ - `metric::Union{SemiMetric, Nothing}`: an instance of Distances Metric object or nothing,
    indicating the distance metric used for calculating point distances.
- - `counts::AbstractVector{Int}`: the optional vector of cluster sizes (how many
-   points assigned to each cluster; should match `assignments`)
- - `nclusters` optional, how many clusters are associated with the assignments (recommended to provide when distances are not provided).
- - `method` optional, one of `[:default, :classis, :cached]`. controls use of cached algorithm.
-   :default selects the best supported algorithm given the metric.
+ - `batch_size::Union{Integer, Nothing}`: if integer is given, calculate silhouettes in batches
+   of `batch_size` points each, throws `DimensionMismatch` if batched calculation
+   is not supported by given `metric`.
 
 # References
 > Peter J. Rousseeuw (1987). *Silhouettes: a Graphical Aid to the
 > Interpretation and Validation of Cluster Analysis*. Computational and
 > Applied Mathematics. 20: 53–65.
-> Marco Gaido (2023). Distributed Silhouette Algorithm: Evaluating Clustering on Big Data 
+> Marco Gaido (2023). Distributed Silhouette Algorithm: Evaluating Clustering on Big Data
 """
-function silhouettes(assignments::AbstractVector{<:Integer}, points:: AbstractMatrix;
-                     metric::Union{Metric, SemiMetric, Nothing}=nothing,
-                     counts::Union{AbstractVector{<:Integer}, Nothing}=nothing,
-                     method::Symbol = :default,
-                     nclusters=maximum(assignments))
-
-    @assert in(method, [:default, :classic, :cached]) "method key argument must be one of :default, :classic or :cached"
-    metric === nothing && @assert(iszero(diag(points)) && issymmetric(points), "silhouettes(): metric not provided, yet points matrix does not seem to be a distances matrix - symmetric and zero on the diagonal.")
-    
-    if method == :default
-        if metric isa SqEuclidean
-            method = :cached
-        else
-            method = :classic
-        end
-    end
-
-    if method == :classic
-        if counts === nothing
-            counts = fill(0, maximum(assignments))
-            for a in assignments
-                counts[a] += 1
-            end
-        end
-        if metric !== nothing
-            dists = pairwise(metric, points, points; dims=2)
-        else
-            dists = points
-        end
-        
-        cluster_to_point = sil_aggregate_distances_normalized(assignments, counts, dists)
-        sil = silhouette_scores(cluster_to_point, assignments, counts)
-
-    elseif  method == :cached
-        !(metric isa SqEuclidean) && throw(ArgumentError("method :cached currently only supports SqEuclidean metric."))
-        batch_size=size(points, 2) # a single batch. May not be optimal. Use `silhouettes_cache` and `silhouettes_using_cache` to change this.
-        dims, n = size(points)
-        check_assignments(assignments, nclusters)
-        pre_calculate::SilhouettesCache = silhouettes_cache(eltype(points), metric, nclusters, dims)
-        batched_x = eachslice(reshape(points, dims, batch_size, trunc(Int, n/batch_size)), dims=3)
-        batched_assignments = eachslice(reshape(assignments, batch_size, trunc(Int, n/batch_size)), dims=2)
-        [pre_calculate(x_batch, a_batch) for (x_batch, a_batch) in zip(batched_x, batched_assignments)] # run through batches of data and update cache
-        silhouettes_streaming = []
-        for (x_batch, a_batch) in zip(batched_x, batched_assignments)
-            silhouettes_streaming = vcat(silhouettes_streaming, silhouettes_using_cache(x_batch, a_batch, pre_calculate)) # calculate each batch using the cache
-        end
-        sil = silhouettes_streaming
-    end
-    return sil
+function silhouettes(assignments::AbstractVector{<:Integer},
+                     points::AbstractMatrix;
+                     metric::Union{SemiMetric, Nothing} = nothing,
+                     batch_size::Union{Integer, Nothing} = nothing)
+    nclusters = maximum(assignments)
+    nclusters >= 2 || throw(ArgumentError("silhouettes() not defined for the degenerated clustering with a single cluster."))
+    check_assignments(assignments, nclusters)
+    return silhouettes(ClusterDistances(metric, assignments, points, batch_size),
+                       assignments, points, batch_size)
 end
 
-silhouettes(R::ClusteringResult, points:: AbstractMatrix;
-            metric::Union{Metric, SemiMetric, Nothing}=nothing,
-            counts::Union{AbstractVector{<:Integer}, Nothing}=nothing,
-            method::Symbol = :default,
-            nclusters=maximum(assignments))= silhouettes(assignments(R), points; metric=metric, counts=counts(R), method=method, nclusters=nclusters)
-
-function silhouettes_using_cache(x::AbstractMatrix{T}, assignments::AbstractVector{<:Integer}, pre::SilhouettesCache{T}) where T<:Real
-    cluster_to_point = sil_aggregate_distances_normalized_streaming(x, assignments, pre)
-    return silhouette_scores(cluster_to_point, assignments, pre.counts)
-end
+silhouettes(R::ClusteringResult, points::AbstractMatrix; kwargs...) =
+    silhouettes(assignments(R), points; kwargs...)

--- a/src/silhouette.jl
+++ b/src/silhouette.jl
@@ -93,7 +93,7 @@ end
 
 function normalize_aggregate_distances!(r, assignments, counts)
     # from sum to average
-    @assert size(r) == (length(counts), length(assignments)) "cluster_to_point matrix dimensions $(size(r)) do not match assignments and counts - $(((length(counts), length(assignments))))"
+    @assert size(r) == (length(counts), length(assignments)) "silhouettes: cluster_to_point matrix dimensions $(size(r)) do not match assignments and counts - $(((length(counts), length(assignments))))"
     @inbounds for j in eachindex(assignments)
         for i in eachindex(counts)
             c = counts[i]
@@ -128,8 +128,8 @@ end
 function sil_aggregate_distances_normalized_streaming(x::AbstractMatrix{T}, assignments::AbstractVector{Int}, pre::SqEuclideanPrecomputeSilhouettes{T}) where T <: Real
     nclusters = pre.nclusters
     check_assignments(assignments, nclusters)
-    size(x, 1) == size(pre.Y, 1) || throw(ArgumentError("number of input features (dimension 1) used in pre computation was $(size(pre.Y, 1)), got $(size(x, 1))"))
-    size(x, 2) == length(assignments) || throw(ArgumentError("number of input points $(size(x, 2)) do not match number of assignments $(length(assignments))"))
+    size(x, 1) == size(pre.Y, 1) || throw(ArgumentError("silhouette: number of input features (dimension 1) used in pre computation was $(size(pre.Y, 1)), got $(size(x, 1))"))
+    size(x, 2) == length(assignments) || throw(ArgumentError("silhouette: number of input points $(size(x, 2)) do not match number of assignments $(length(assignments))"))
 
     # compute average distance from each cluster to each point --> r
     ξx = sum(abs2, x; dims=1) # [1,n]

--- a/src/silhouette.jl
+++ b/src/silhouette.jl
@@ -93,6 +93,7 @@ end
 
 function normalize_aggregate_distances!(r, assignments, counts)
     # from sum to average
+    @assert size(r) == (length(counts), length(assignments)) "cluster_to_point matrix dimensions $(size(r)) do not match assignments and counts - $(((length(counts), length(assignments))))"
     @inbounds for j in eachindex(assignments)
         for i in eachindex(counts)
             c = counts[i]
@@ -127,7 +128,8 @@ end
 function sil_aggregate_distances_normalized_streaming(x::AbstractMatrix{T}, assignments::AbstractVector{Int}, pre::SqEuclideanPrecomputeSilhouettes{T}) where T <: Real
     nclusters = pre.nclusters
     check_assignments(assignments, nclusters)
-    size(x, 1) == size(pre.Y, 1) || throw(ArgumentError("input features dimension does not match with precomputation on dimension 1"))
+    size(x, 1) == size(pre.Y, 1) || throw(ArgumentError("number of input features (dimension 1) used in pre computation was $(size(pre.Y, 1)), got $(size(x, 1))"))
+    size(x, 2) == length(assignments) || throw(ArgumentError("number of input points $(size(x, 2)) do not match number of assignments $(length(assignments))"))
 
     # compute average distance from each cluster to each point --> r
     ξx = sum(abs2, x; dims=1) # [1,n]

--- a/src/silhouette.jl
+++ b/src/silhouette.jl
@@ -51,7 +51,7 @@ function silhouettes_precompute_batch!(pre::SqEuclideanPrecomputedSilhouettes{T}
         pre.counts[val] += cnt
     end
     @assert n == length(assignments) "data matrix dimensions must be (..., $(length(assignments))) and got $(size(x))"
-    ξ = sum(x.^2; dims=1) # [1,n]
+    ξ = sum(abs2, x; dims=1) # [1,n]
     # precompute vectors
     @inbounds for (i, cluster) in enumerate(assignments)
         pre.Y[:, cluster] .+= view(x, :, i)

--- a/src/silhouette.jl
+++ b/src/silhouette.jl
@@ -10,8 +10,8 @@ end
 
 """
 SilhouettesDistsPrecompute(k::Int, d::Int, ::Type{T})
-Precomputations container for [@silhouettes_precompute_batch!].
-See also [`silhouettes`](@ref), [`silhouettes_precompute_batch`](@ref)
+Precomputations container for [`silhouettes_precompute_batch!`](@ref).
+See also [`silhouettes`](@ref), [`silhouettes_precompute_batch!`](@ref)
 """
 SilhouettesDistsPrecompute(k::Int, d::Int, ::Type{T}) where T<:Real= SilhouettesDistsPrecompute{T}(k, d, 
                                                                                       zeros(Int, k, 1),

--- a/src/silhouette.jl
+++ b/src/silhouette.jl
@@ -179,7 +179,9 @@ end
 """
     silhouettes(assignments::AbstractVector, [counts,] dists) -> Vector{Float64}
     silhouettes(clustering::ClusteringResult, dists) -> Vector{Float64}
-    silhouettes(x::AbstractMatrix, assignments::AbstractVector, pre::SqEuclideanPrecomputeSilhouettes) -> Vector{Float64}
+    silhouettes(x::AbstractMatrix, assignments::AbstractVector, pre::PrecomputeSilhouettes) -> Vector{Float64}
+    silhouettes(metric::Union{Metric, SemiMetric}, assignments::AbstractVector{<:Integer}, x::AbstractMatrix; 
+                nclusters=maximum(assignments), batch_size=size(x, 2), pre_calculate::Bool=true)
 
 Compute *silhouette* values for individual points w.r.t. given clustering.
 
@@ -194,7 +196,13 @@ Returns the ``n``-length vector of silhouette values for each individual point.
  - `dists::AbstractMatrix`: ``n×n`` matrix of pairwise distances between
    the points
  - `x::AbstractMatrix`: `d×n`` matrix of ``n`` data features of dimensionality ``d``
- - `pre::SqEuclideanPrecomputeSilhouettes`: precomputed vectors of cluster silhouettes.
+ - `pre::PrecomputeSilhouettes`: precomputed vectors of cluster silhouettes.
+ - `metric::Union{Metric, SemiMetric}`: Distances metric object specifying which 
+   metric should be used to calculate the distances when given x.
+ - `nclusters` optional, how many clusters are associated with the assignments.
+ - `batch_size` optional, what batch size to use for distributed calculation, 
+    when available. Does not apply to direct use of `PrecomputeSilhouettes`.
+ - `pre_calculate` optional, control use of distributed algorithm (recommended by default).
 
 # References
 > Peter J. Rousseeuw (1987). *Silhouettes: a Graphical Aid to the

--- a/src/silhouette.jl
+++ b/src/silhouette.jl
@@ -1,94 +1,92 @@
 # Silhouette
 
-mutable struct SilhouettesDistsPrecompute{T}
-    k::Int
-    d::Int
-    counts::Matrix{Int} #[k, 1]
-    Ψ::Matrix{T} #[k, 1]
-    Y::Matrix{T} #[d, k]
+struct SqEuclideanPrecomputedSilhouettes{T}
+    nclusters::Int
+    dims::Int
+    counts::Vector{Int} #[nclusters, 1]
+    Ψ::Vector{T} #[nclusters], This represents the second moments of each cluster
+    Y::Matrix{T} #[dims, nclusters], This represents the first moments of each cluster
+    """
+    SqEuclideanPrecomputedSilhouettes(::Type{T}, nclusters::Int, dims::Int)
+    Precomputations container for [`silhouettes_precompute_batch!`](@ref).
+    See also [`silhouettes`](@ref), [`silhouettes_precompute_batch!`](@ref)
+    """
+    SqEuclideanPrecomputedSilhouettes(::Type{T}, nclusters::Int, dims::Int) where T<:Real= new{T}(nclusters, dims, 
+                                                                                                  zeros(Int, nclusters),
+                                                                                                  zeros(T, nclusters), 
+                                                                                                  zeros(T, dims, nclusters))
 end
 
-"""
-SilhouettesDistsPrecompute(k::Int, d::Int, ::Type{T})
-Precomputations container for [`silhouettes_precompute_batch!`](@ref).
-See also [`silhouettes`](@ref), [`silhouettes_precompute_batch!`](@ref)
-"""
-SilhouettesDistsPrecompute(k::Int, d::Int, ::Type{T}) where T<:Real= SilhouettesDistsPrecompute{T}(k, d, 
-                                                                                      zeros(Int, k, 1),
-                                                                                      zeros(T, k, 1), 
-                                                                                      zeros(T, d, k))
-
-                                                                                      # this does the same as sil_aggregate_dists, but uses the method in "Distributed Silhouette Algorithm: Evaluating Clustering on Big Data"
+# this does the same as sil_aggregate_dists, but uses the method in "Distributed Silhouette Algorithm: Evaluating Clustering on Big Data"
 # https://arxiv.org/abs/2303.14102
 # this implementation uses the SqEuclidean distance only
 """
-silhouettes_precompute_batch!(k::Int, assignments::AbstractVector{Int}, x::AbstractMatrix{T}, pre::SilhouettesDistsPrecompute{T}) where T<:Real
+silhouettes_precompute_batch!(pre::SqEuclideanPrecomputedSilhouettes{T}, assignments::AbstractVector{Int}, x::AbstractMatrix{T}) where T<:Real
 Include a batch of data and cluster assignments (x,a) in the precomputations for silhouettes.
 This implementation supports only square Euclidean distances at present.
-See also [`silhouettes`](@ref) [`SilhouettesDistsPrecompute`](@ref)
+See also [`silhouettes`](@ref) [`SqEuclideanPrecomputedSilhouettes`](@ref)
 
 # Examples:
 ```julia-repl
-Julia> k=10; d=3; bs=100; n=10000;
-Julia> pre = SilhouettesDistsPrecompute(k, d, Float32);
+Julia> nclusters=10; d=3; bs=100; n=10000;
+Julia> pre = SqEuclideanPrecomputedSilhouettes(Float32, nclusters, d);
 Julia> x = reshape(collect(Float32, 1:30000), 3, n); # direct computation is impractical on such a big dataset
-Julia> a = reshape(repeat(collect(1:k),trunc(Int, n/k)), n);
+Julia> a = reshape(repeat(collect(1:nclusters),trunc(Int, n/nclusters)), n);
 Julia> batches_x = eachslice(reshape(x, 3, trunc(Int, n/bs), bs); dims=3); batches_a = eachslice(reshape(a, trunc(Int, n/bs), bs); dims=2);
-Julia> @time [silhouettes_precompute_batch!(k, aa, xx, pre) for (xx, aa) in zip(batches_x, batches_a)]; # precompute vectors on big data
+Julia> @time [silhouettes_precompute_batch!(nclusters, aa, xx, pre) for (xx, aa) in zip(batches_x, batches_a)]; # precompute vectors on big data
 0.838358 seconds (2.06 M allocations: 141.495 MiB, 4.24% gc time, 99.00% compilation time)
 Julia> @time sil = vcat([silhouettes(xx, aa, pre) for (xx, aa) in zip(batches_x, batches_a)]); # calculate silhouette scores in batched fashion
-0.049759 seconds (53.78 k allocations: 4.440 MiB, 98.54% compilation time)
+0.049759 seconds (53.78 nclusters allocations: 4.440 MiB, 98.54% compilation time)
 Julia> size(sil)
 (10000,)
 ```
 """
-function silhouettes_precompute_batch!(k::Int, a::AbstractVector{Int}, x::AbstractMatrix{T}, pre::SilhouettesDistsPrecompute{T}) where T<:Real
+function silhouettes_precompute_batch!(pre::SqEuclideanPrecomputedSilhouettes{T}, assignments::AbstractVector{Int}, x::AbstractMatrix{T}) where T<:Real
     # x dims are [D,N]
     d, n = size(x)
-    all(1 .<= a .<= k) || throw(ArgumentError("Bad assignments: should be in 1:$k range."))
-    d == pre.d || throw(ArgumentError("Bad data: x[1]=$d must match pre.d=$(pre.d)."))
+    check_assignments(assignments, pre.nclusters)
+    d == pre.dims || throw(ArgumentError("Bad data: x[1]=$d must match pre.d=$(pre.d)."))
     # update counts
-    for (val, cnt) in countmap(a)
+    for (val, cnt) in countmap(assignments)
         pre.counts[val] += cnt
     end
-    @assert n == length(a) "data matrix dimensions must be (..., $(length(a))) and got $(size(x))"
+    @assert n == length(assignments) "data matrix dimensions must be (..., $(length(assignments))) and got $(size(x))"
     ξ = sum(x.^2; dims=1) # [1,n]
     # precompute vectors
-    for kk in 1:k
-        @inbounds pre.Y[:, kk] += sum((reshape(a, 1, n) .== kk) .* x; dims=2)
-        @inbounds pre.Ψ[kk] += sum((reshape(a, 1, n) .== kk) .* ξ)
+    @inbounds for (i, cluster) in enumerate(assignments)
+        pre.Y[:, cluster] .+= view(x, :, i)
+        pre.Ψ[cluster] += ξ[i]
     end
+    return pre
 end
 
-function silhouettes_precompute_batch!(R::ClusteringResult, 
-                                              x::AbstractMatrix{T}, 
-                                              pre::SilhouettesDistsPrecompute{T}) where T<:Real
-    silhouettes_precompute_batch!(nclusters(R), assignments(R), x, pre)
-end
+silhouettes_precompute_batch!(pre::SqEuclideanPrecomputedSilhouettes{T}, 
+                              R::ClusteringResult, 
+                              x::AbstractMatrix{T}) where T<:Real = silhouettes_precompute_batch!(pre, assignments(R), x)
 
-# this function returns r of size (k, n), such that
+# this function returns r of size (nclusters, n), such that
 # r[i, j] is the sum of distances of all points from cluster i to point j
 #
-function sil_aggregate_dists(k::Int, a::AbstractVector{Int}, dists::AbstractMatrix{T}) where T<:Real
-    n = length(a)
+function sil_aggregate_dists(nclusters::Int, assignments::AbstractVector{Int}, dists::AbstractMatrix{T}) where T<:Real
+    n = length(assignments)
     S = typeof((one(T)+one(T))/2)
-    r = zeros(S, k, n)
+    r = zeros(S, nclusters, n)
     @inbounds for j = 1:n
         for i = 1:j-1
-            r[a[i],j] += dists[i,j]
+            r[assignments[i],j] += dists[i,j]
         end
         for i = j+1:n
-            r[a[i],j] += dists[i,j]
+            r[assignments[i],j] += dists[i,j]
         end
     end
     return r
 end
 
-function normalize_aggregate_dists!(r, assignments, counts, k, n)
+function normalize_aggregate_distances!(r, assignments, counts)
     # from sum to average
-    @inbounds for j = 1:n
-        for i = 1:k
-            c = copy(counts[i])
+    @inbounds for j in eachindex(assignments)
+        for i in eachindex(counts)
+            c = counts[i]
             if i == assignments[j]
                 c -= 1
             end
@@ -102,53 +100,52 @@ function normalize_aggregate_dists!(r, assignments, counts, k, n)
     return r
 end
 
-function sil_aggregate_dists_normalized(assignments::AbstractVector{<:Integer},
+function sil_aggregate_distances_normalized(assignments::AbstractVector{<:Integer},
                                         counts::AbstractVector{<:Integer},
                                         dists::AbstractMatrix{T}) where T<:Real
     n = length(assignments)
-    k = length(counts)
-    k >= 2 || throw(ArgumentError("silhouettes() not defined for the degenerated clustering with a single cluster."))
-    for j = 1:n
-        (1 <= assignments[j] <= k) || throw(ArgumentError("Bad assignments[$j]=$(assignments[j]): should be in 1:$k range."))
-    end
+    nclusters = length(counts)
+    nclusters >= 2 || throw(ArgumentError("silhouettes() not defined for the degenerated clustering with a single cluster."))
+    check_assignments(assignments, nclusters)
     sum(counts) == n || throw(ArgumentError("Mismatch between assignments ($n) and counts (sum(counts)=$(sum(counts)))."))
     size(dists) == (n, n) || throw(DimensionMismatch("The size of a distance matrix ($(size(dists))) doesn't match the length of assignment vector ($n)."))
 
     # compute average distance from each cluster to each point --> r
-    r = sil_aggregate_dists(k, assignments, dists)
-    r = normalize_aggregate_dists!(r, assignments, counts, k, n)
-    return r
+    cluster_to_point = sil_aggregate_dists(nclusters, assignments, dists)
+    cluster_to_point = normalize_aggregate_distances!(cluster_to_point, assignments, counts)
+    return cluster_to_point
 end
 
-function sil_aggregate_dists_normalized_streaming(x::AbstractMatrix{T}, assignments::AbstractVector{Int}, pre::SilhouettesDistsPrecompute{T}) where T <: Real
-    k = pre.k
+function sil_aggregate_distances_normalized_streaming(x::AbstractMatrix{T}, assignments::AbstractVector{Int}, pre::SqEuclideanPrecomputedSilhouettes{T}) where T <: Real
+    nclusters = pre.nclusters
     n = size(x, 2)
-    k >= 2 || throw(ArgumentError("silhouettes() not defined for the degenerated clustering with a single cluster."))
+    nclusters >= 2 || throw(ArgumentError("silhouettes() not defined for the degenerated clustering with a single cluster."))
     size(x, 1) == size(pre.Y, 1) || throw(ArgumentError("input features dimension does not match with precomputation on dimension 1"))
 
     # compute average distance from each cluster to each point --> r
-    ξx = sum(x.^2; dims=1) # [1,n]
-    r = pre.counts .* ξx .+ pre.Ψ .- 2 .* transpose(pre.Y) * x # r is [k, n]
-    r = normalize_aggregate_dists!(r, assignments, pre.counts, k, n)
-    return r
+    ξx = sum(abs2, x; dims=1) # [1,n]
+    cluster_to_point = reshape(pre.counts, :, 1) .* ξx .+ reshape(pre.Ψ, pre.nclusters, 1) .- 2 .* transpose(pre.Y) * x # cluster_to_point is [nclusters, n]
+    cluster_to_point = normalize_aggregate_distances!(cluster_to_point, assignments, pre.counts)
+    return cluster_to_point
 end
 
-function silhouettes_given_dist(r::Matrix{T}, assignments::AbstractVector{Int}, counts::Vector{Int}) where {T}
+# compute silhouette scores for each point given a matrix of cluster-to-point distances
+function silhouette_scores(cluster_to_point::AbstractMatrix{<:Real}, assignments::AbstractVector{Int}, counts::Vector{Int})
     n = length(assignments)
     # compute a and b
     # a: average distance w.r.t. the assigned cluster
     # b: the minimum average distance w.r.t. other cluster
-    a = similar(r, n)
-    b = similar(r, n)
-    k = length(counts)
+    a = similar(cluster_to_point, n)
+    b = similar(cluster_to_point, n)
+    nclusters = length(counts)
     for j = 1:n
         l = assignments[j]
-        a[j] = r[l, j]
+        a[j] = cluster_to_point[l, j]
 
         v = typemax(eltype(b))
-        @inbounds for i = 1:k
+        @inbounds for i = 1:nclusters
             counts[i] == 0 && continue # skip empty clusters
-            rij = r[i,j]
+            rij = cluster_to_point[i,j]
             if (i != l) && (rij < v)
                 v = rij
             end
@@ -165,7 +162,7 @@ function silhouettes_given_dist(r::Matrix{T}, assignments::AbstractVector{Int}, 
             #If both a[i] and b[i] are equal to 0 or Inf, silhouettes is defined as 0
             @inbounds sil[j] = a[j] < b[j] ? 1 - a[j]/b[j] :
                                a[j] > b[j] ? b[j]/a[j] - 1 :
-                               zero(eltype(r))
+                               zero(eltype(cluster_to_point))
         end
     end
     return sil
@@ -175,7 +172,7 @@ end
 """
     silhouettes(assignments::AbstractVector, [counts,] dists) -> Vector{Float64}
     silhouettes(clustering::ClusteringResult, dists) -> Vector{Float64}
-    silhouettes(x::AbstractMatrix, assignments::AbstractVector, pre::SilhouettesDistsPrecompute) -> Vector{Float64}
+    silhouettes(x::AbstractMatrix, assignments::AbstractVector, pre::SqEuclideanPrecomputedSilhouettes) -> Vector{Float64}
 
 Compute *silhouette* values for individual points w.r.t. given clustering.
 
@@ -190,7 +187,7 @@ Returns the ``n``-length vector of silhouette values for each individual point.
  - `dists::AbstractMatrix`: ``n×n`` matrix of pairwise distances between
    the points
  - `x::AbstractMatrix`: `d×n`` matrix of ``n`` data features of dimensionality ``d``
- - `pre::SilhouettesDistsPrecompute`: precomputed vectors of cluster silhouettes.
+ - `pre::SqEuclideanPrecomputedSilhouettes`: precomputed vectors of cluster silhouettes.
 
 # References
 > Peter J. Rousseeuw (1987). *Silhouettes: a Graphical Aid to the
@@ -202,13 +199,13 @@ function silhouettes(assignments::AbstractVector{<:Integer},
                      counts::AbstractVector{<:Integer},
                      dists::AbstractMatrix{T}) where T<:Real
 
-    r = sil_aggregate_dists_normalized(assignments, counts, dists)
-    return silhouettes_given_dist(r, assignments, counts)
+    cluster_to_point = sil_aggregate_distances_normalized(assignments, counts, dists)
+    return silhouette_scores(cluster_to_point, assignments, counts)
 end
 
-function silhouettes(x::AbstractMatrix{T}, assignments::AbstractVector{<:Integer}, pre::SilhouettesDistsPrecompute{T}) where T<:Real
-    r = sil_aggregate_dists_normalized_streaming(x, assignments, pre)
-    return silhouettes_given_dist(r, assignments, reshape(pre.counts, :))
+function silhouettes(x::AbstractMatrix{T}, assignments::AbstractVector{<:Integer}, pre::SqEuclideanPrecomputedSilhouettes{T}) where T<:Real
+    cluster_to_point = sil_aggregate_distances_normalized_streaming(x, assignments, pre)
+    return silhouette_scores(cluster_to_point, assignments, pre.counts)
 end
 
 silhouettes(R::ClusteringResult, dists::AbstractMatrix) =

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -76,3 +76,9 @@ function updatemin!(r::AbstractArray, x::AbstractArray)
     end
     return r
 end
+
+function check_assignments(assignments, nclusters)
+    for j in eachindex(assignments)
+        all(1 <= assignments[j] <= nclusters) || throw(ArgumentError("Bad assignments[$j]=$(assignments[j]): should be in 1:$nclusters range."))
+    end
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -78,6 +78,7 @@ function updatemin!(r::AbstractArray, x::AbstractArray)
 end
 
 function check_assignments(assignments, nclusters)
+    nclusters >= 2 || throw(ArgumentError("silhouettes() not defined for the degenerated clustering with a single cluster."))
     for j in eachindex(assignments)
         all(1 <= assignments[j] <= nclusters) || throw(ArgumentError("Bad assignments[$j]=$(assignments[j]): should be in 1:$nclusters range."))
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -77,9 +77,9 @@ function updatemin!(r::AbstractArray, x::AbstractArray)
     return r
 end
 
-function check_assignments(assignments, nclusters)
-    nclusters >= 2 || throw(ArgumentError("silhouettes() not defined for the degenerated clustering with a single cluster."))
-    for j in eachindex(assignments)
-        all(1 <= assignments[j] <= nclusters) || throw(ArgumentError("Bad assignments[$j]=$(assignments[j]): should be in 1:$nclusters range."))
+function check_assignments(assignments::AbstractVector{<:Integer}, nclusters::Union{Integer, Nothing})
+    nclu = nclusters === nothing ? maximum(assignments) : nclusters
+    for (j, c) in enumerate(assignments)
+        all(1 <= c <= nclu) || throw(ArgumentError("Bad assignments[$j]=$c: should be in 1:$nclu range."))
     end
 end

--- a/test/silhouette.jl
+++ b/test/silhouette.jl
@@ -11,29 +11,20 @@ local D = [0 1 2 3
 
 @assert size(D) == (4, 4)
 
-local a = [1, 1, 2, 2]
-local c = [2, 2]
-
 @testset "Input checks" begin
-    @test_skip silhouettes(a, D; counts=[1, 1, 2]) # should throw because cluster counts are inconsistent
-    @test_throws ArgumentError silhouettes(a, D; counts=[3, 2])
-    @test_throws ArgumentError silhouettes([1, 1, 3, 2], D; counts=[2, 2])
-    @test_throws DimensionMismatch silhouettes([1, 1, 2, 2, 2], D; counts=[2, 3])
+    @test_throws DimensionMismatch silhouettes([1, 1, 3, 2], D[1:4, 1:3])
+    @test_throws DimensionMismatch silhouettes([1, 1, 2, 2, 2], D)
+    @test_throws Exception silhouettes([1, 1, 2, 2, 2], D, batch_size=3)
+    D2 = copy(D)
+    D2[2, 3] = 4
+    @test_throws ArgumentError silhouettes([1, 1, 2, 2], D2)
 end
 
-@test @inferred(silhouettes(a, D; counts=c)) ≈ [1.5/2.5, 0.5/1.5, 0.5/1.5, 1.5/2.5]
-@test @inferred(silhouettes(a, convert(Matrix{Float32}, D); counts=c)) isa AbstractVector{Float32}
-@test silhouettes(a, D) == silhouettes(a, D; counts=c) # c is optional
+@test @inferred(silhouettes([1, 1, 2, 2], D)) ≈ [1.5/2.5, 0.5/1.5, 0.5/1.5, 1.5/2.5]
+@test @inferred(silhouettes([1, 1, 2, 2], convert(Matrix{Float32}, D))) isa AbstractVector{Float32}
 
-a = [1, 2, 1, 2]
-c = [2, 2]
-
-@test silhouettes(a, D; counts=c) ≈ [0.0, -0.5, -0.5, 0.0]
-
-a = [1, 1, 1, 2]
-c = [3, 1]
-
-@test silhouettes(a, D; counts=c) ≈ [0.5, 0.5, -1/3, 0.0]
+@test silhouettes([1, 2, 1, 2], D) ≈ [0.0, -0.5, -0.5, 0.0]
+@test silhouettes([1, 1, 1, 2], D) ≈ [0.5, 0.5, -1/3, 0.0]
 
 @testset "zero cluster distances correctly" begin
     a = [fill(1, 5); fill(2, 5)]
@@ -57,55 +48,36 @@ end
 end
 
 @testset "empty clusters handled correctly (#241)" begin
-    X = rand(MersenneTwister(123), 10, 5)
-    pd = pairwise(Euclidean(), X, dims=1)
-    @test all(>=(-0.5), silhouettes([5, 2, 2, 3, 2, 2, 3, 2, 3, 5], pd))
+    X = rand(MersenneTwister(123), 3, 10)
+    pd = pairwise(Euclidean(), X, dims=2)
+    asgns = [5, 2, 2, 3, 2, 2, 3, 2, 3, 5]
+    @test all(>=(-0.5), silhouettes(asgns, pd))
+    @test all(>=(-0.5), silhouettes(asgns, X, metric=Euclidean()))
 end
 
-@testset "streaming silhouettes" begin
-    import Clustering: sil_aggregate_distances_normalized_streaming, sil_aggregate_distances_normalized, silhouettes_using_cache, silhouettes_cache
-    nclusters = 10
-    dims = 3
-    n = 100
-    X = rand(MersenneTwister(123), dims, n)
-    pd = pairwise(SqEuclidean(), X, dims=2)
-    a = rand(1:nclusters, n)
-    stats1 = @timed s_standard = silhouettes(a, pd)
-    stats2 = @timed s_streaming_at_once = silhouettes(a, X; metric=SqEuclidean(), nclusters=nclusters)
-    
-    @test isapprox(s_standard, s_streaming_at_once)
-    
-    pre_at_init = silhouettes_cache(eltype(X), SqEuclidean(), nclusters, dims)
-    pre = silhouettes_cache(eltype(X), SqEuclidean(), nclusters, dims)
-    pre_all_at_once = silhouettes_cache(eltype(X), SqEuclidean(), nclusters, dims)
-    batch_size = 10
-    for (x, aa) in zip(eachslice(reshape(X, dims, batch_size, trunc(Int, n/batch_size)), dims=3), 
-                       eachslice(reshape(a, batch_size, trunc(Int, n/batch_size)), dims=2))
-        pre = pre(x, aa)
-    end
-    pre_all_at_once = pre_all_at_once(X, a)
-    # counts sanity test
-    @test sum(pre.counts) == n
-    # make sure the batched calculation is the same as calculating all at once
-    @test pre.counts == pre_all_at_once.counts
-    @test pre.counts != pre_at_init.counts
-    @test pre.Ψ != pre_at_init.Ψ
-    @test pre.Y != pre_at_init.Y
-    @test isapprox(pre.Ψ, pre_all_at_once.Ψ)
-    @test isapprox(pre.Y, pre_all_at_once.Y)
+@testset "silhouettes(metric=$metric, batch_size=$(batch_size !== nothing ? batch_size : "nothing"))" for
+        (metric, batch_size, supported) in [
+            (Euclidean(), nothing, true),
+            (Euclidean(), 1000, true),
+            (Euclidean(), 10, false),
 
-    # compare with standard calculation results
-    r_standard = sil_aggregate_distances_normalized(a, reshape(pre.counts, :), pd)
-    r_streaming = sil_aggregate_distances_normalized_streaming(X, a, pre)
-    @test isapprox(r_standard, r_streaming)
+            (SqEuclidean(), nothing, true),
+            (SqEuclidean(), 1000, true),
+            (SqEuclidean(), 10, true),
+        ]
 
-    s_streaming = []
-    for (x, aa) in zip(eachslice(reshape(X, dims, batch_size, trunc(Int, n/batch_size)), dims=3), 
-                       eachslice(reshape(a, batch_size, trunc(Int, n/batch_size)), dims=2))
-        s_streaming = vcat(s_streaming, silhouettes_using_cache(x, aa, pre))
+    Random.seed!(123)
+    X = rand(3, 100)
+    pd = pairwise(metric, X, dims=2)
+    a = rand(1:10, size(X, 2))
+    kmeans_clu = kmeans(X, 5)
+    if supported
+        @test silhouettes(a, X; metric=metric, batch_size=batch_size) ≈ silhouettes(a, pd)
+        @test silhouettes(kmeans_clu, X; metric=metric, batch_size=batch_size) ≈ silhouettes(kmeans_clu, pd)
+    else
+        @test_throws Exception silhouettes(a, X; metric=metric, batch_size=batch_size)
+        @test_throws Exception silhouettes(kmeans_clu, X; metric=metric, batch_size=batch_size)
     end
-    # compare final scores with standard calculation results
-    @test isapprox(s_standard, s_streaming)
 end
 
 end

--- a/test/silhouette.jl
+++ b/test/silhouette.jl
@@ -77,9 +77,9 @@ end
     batch_size = 10
     for (x, aa) in zip(eachslice(reshape(X, dims, batch_size, trunc(Int, n/batch_size)), dims=3), 
                        eachslice(reshape(a, batch_size, trunc(Int, n/batch_size)), dims=2))
-        pre = silhouettes_precompute_batch!(pre, aa, x)
+        pre = precompute_silhouettes(pre, aa, x)
     end
-    pre_all_at_once = silhouettes_precompute_batch!(pre_all_at_once, a, X)
+    pre_all_at_once = precompute_silhouettes(pre_all_at_once, a, X)
     # counts sanity test
     @test sum(pre.counts) == n
     # make sure the batched calculation is the same as calculating all at once

--- a/test/silhouette.jl
+++ b/test/silhouette.jl
@@ -61,4 +61,41 @@ end
     @test all(>=(-0.5), silhouettes([5, 2, 2, 3, 2, 2, 3, 2, 3, 5], pd))
 end
 
+@testset "streaming silhouettes" begin
+    import Clustering: sil_aggregate_dists_normalized_streaming, sil_aggregate_dists_normalized
+    using Distances, Clustering, Random
+    k = 10
+    d = 3
+    n = 100
+    X = rand(MersenneTwister(123), d, n)
+    pd = pairwise(SqEuclidean(), X, dims=2)
+    a = rand(1:k, n)
+    s_standard = silhouettes(a, pd)
+    pre = SilhouettesDistsPrecompute(k, d, eltype(X))
+    pre_all_at_once = SilhouettesDistsPrecompute(k, d, eltype(X))
+    bs = 10
+    for (x, aa) in zip(eachslice(reshape(X, d, bs, trunc(Int, n/bs)), dims=3), eachslice(reshape(a, bs, trunc(Int, n/bs)), dims=2))
+        silhouettes_precompute_batch!(k, aa, x, pre)
+    end
+    silhouettes_precompute_batch!(k, a, X, pre_all_at_once)
+    # counts sanity test
+    @test sum(pre.counts) == n
+    # make sure the batched calculation is the same as calculating all at once
+    @test pre.counts == pre_all_at_once.counts
+    @test isapprox(pre.Ψ,pre_all_at_once.Ψ)
+    @test isapprox(pre.Y,pre_all_at_once.Y)
+
+    # compare with standard calculation results
+    r_standard = sil_aggregate_dists_normalized(a, reshape(pre.counts, :), pd)
+    r_streaming = sil_aggregate_dists_normalized_streaming(X, a, pre)
+    @test isapprox(r_standard, r_streaming)
+
+    s_streaming = []
+    for (x, aa) in zip(eachslice(reshape(X, d, bs, trunc(Int, n/bs)), dims=3), eachslice(reshape(a, bs, trunc(Int, n/bs)), dims=2))
+        s_streaming = vcat(s_streaming, silhouettes(x, aa, pre))
+    end
+    # compare final scores with standard calculation results
+    @test isapprox(s_standard, s_streaming)
+end
+
 end


### PR DESCRIPTION
This PR implements a distributed implementation of silhouette score
https://arxiv.org/pdf/2303.14102.pdf

This implementation only supports Square Euclidean metric at the moment, but the extension to some (not all) other metrics is straightforward. See the paper.

This PR includes:
- Docs incl. usage example (see below)
- Implementation
- a bit of a refactor of the existing silhouette code (break it down into more functions to reuse in the new distributed implementation).
- Unit tests of the new implementation, including a comparison with the usual implementation.

Example including benchmarking
```
Julia> k=10; d=3; bs=100; n=10000;
Julia> pre = SilhouettesDistsPrecompute(k, d, Float32);
Julia> x = reshape(collect(Float32, 1:30000), 3, n); # direct computation is impractical on such a big dataset
Julia> a = reshape(repeat(collect(1:k),trunc(Int, n/k)), n);
Julia> batches_x = eachslice(reshape(x, 3, trunc(Int, n/bs), bs); dims=3); batches_a = eachslice(reshape(a, trunc(Int, n/bs), bs); dims=2);
Julia> @time [silhouettes_precompute_batch!(k, aa, xx, pre) for (xx, aa) in zip(batches_x, batches_a)]; # precompute vectors on big data
0.838358 seconds (2.06 M allocations: 141.495 MiB, 4.24% gc time, 99.00% compilation time)
Julia> @time sil = vcat([silhouettes(xx, aa, pre) for (xx, aa) in zip(batches_x, batches_a)]); # calculate silhouette scores in batched fashion
0.049759 seconds (53.78 k allocations: 4.440 MiB, 98.54% compilation time)
Julia> size(sil)
(10000,)
```
