### PR TITLE
Update to Distances.jl 0.10.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-Distances = "0.8, 0.9, 0.10"
+Distances = "0.10.9"
 NearestNeighbors = "0.4"
 StatsBase = "0.25, 0.26, 0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33, 0.34"
 julia = "1"

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -169,11 +169,11 @@ function _kmeans!(X::AbstractMatrix{<:Real},                # in: data matrix (d
         end
 
         if t == 1 || num_affected > 0.75 * k
-            pairwise!(dmat, distance, centers, X, dims=2)
+            pairwise!(distance, dmat, centers, X, dims=2)
         else
             # if only a small subset is affected, only compute for that subset
             affected_inds = findall(to_update)
-            pairwise!(view(dmat, affected_inds, :), distance,
+            pairwise!(distance, view(dmat, affected_inds, :),
                       view(centers, :, affected_inds), X, dims=2)
         end
 
@@ -387,7 +387,7 @@ function repick_unused_centers(X::AbstractMatrix{<:Real}, # in: the data matrix 
         tcosts[j] = 0
         v = view(X, :, j)
         centers[:, i] = v
-        colwise!(ds, distance, v, X)
+        colwise!(distance, ds, v, X)
         tcosts = min(tcosts, ds)
     end
 end

--- a/src/seeding.jl
+++ b/src/seeding.jl
@@ -181,7 +181,7 @@ function initseeds!(iseeds::AbstractVector{<:Integer}, alg::KmppAlg,
 
             # update mincosts
             c = view(X, :, p)
-            colwise!(tmpcosts, metric, X, view(X, :, p))
+            colwise!(metric, tmpcosts, X, view(X, :, p))
             updatemin!(mincosts, tmpcosts)
             mincosts[p] = 0
         end

--- a/test/kmeans.jl
+++ b/test/kmeans.jl
@@ -11,7 +11,7 @@ rng = StableRNG(42)
 struct MySqEuclidean <: SemiMetric end
 
 # redefinition of Distances.pairwise! for MySqEuclidean type
-function Distances.pairwise!(r::AbstractMatrix, dist::MySqEuclidean,
+function Distances.pairwise!(dist::MySqEuclidean, r::AbstractMatrix,
                              a::AbstractMatrix, b::AbstractMatrix; dims::Integer=2)
     dims == 2 || throw(ArgumentError("only dims=2 supported for MySqEuclidean distance"))
     mul!(r, transpose(a), b)


### PR DESCRIPTION
In 0.10.9 the signature of `pairwise()`/`colwise()` etc changed to have metric as the first argument (see JuliaStats/Distances.jl#239).