### PR TITLE
fuzzycmeans() enhancements

### DIFF
--- a/docs/source/fuzzycmeans.md
+++ b/docs/source/fuzzycmeans.md
@@ -5,16 +5,15 @@ is a clustering method that provides cluster membership weights instead
 of "hard" classification (e.g. K-means).
 
 From a mathematical standpoint, fuzzy C-means solves the following
-optimization
-problem:
+optimization problem:
 ```math
-\arg\min_C \ \sum_{i=1}^n \sum_{j=1}^c w_{ij}^m \| \mathbf{x}_i - \mathbf{c}_{j} \|^2, \
-\text{where}\ w_{ij} = \left(\sum_{k=1}^{c} \left(\frac{\left\|\mathbf{x}_i - \mathbf{c}_j \right\|}{\left\|\mathbf{x}_i - \mathbf{c}_k \right\|}\right)^{\frac{2}{m-1}}\right)^{-1}
+\arg\min_\mathcal{C} \ \sum_{i=1}^n \sum_{j=1}^C w_{ij}^\mu \| \mathbf{x}_i - \mathbf{c}_j \|^2, \
+\text{where}\ w_{ij} = \left(\sum_{k=1}^{C} \left(\frac{\left\|\mathbf{x}_i - \mathbf{c}_j \right\|}{\left\|\mathbf{x}_i - \mathbf{c}_k \right\|}\right)^{\frac{2}{\mu-1}}\right)^{-1}
 ```
 
 Here, ``\mathbf{c}_j`` is the center of the ``j``-th cluster, ``w_{ij}``
 is the membership weight of the ``i``-th point in the ``j``-th cluster,
-and ``m > 1`` is a user-defined fuzziness parameter.
+and ``\mu > 1`` is a user-defined fuzziness parameter.
 
 ```@docs
 fuzzy_cmeans

--- a/src/fuzzycmeans.jl
+++ b/src/fuzzycmeans.jl
@@ -140,12 +140,12 @@ function _fuzzy_cmeans(
         end
     end
 
-    if displevel >= 1
-        if δ <= tol
-            println("Fuzzy C-means converged with $iter iterations (δ = $δ)")
-        else
-            println("Fuzzy C-means terminated without convergence after $iter iterations (δ = $δ)")
+    if δ <= tol
+        if displevel >= 1
+            @info "Fuzzy C-means converged with $iter iterations (δ = $δ)"
         end
+    else
+        @warn "Fuzzy C-means terminated without convergence after $iter iterations (δ = $δ)"
     end
 
     FuzzyCMeansResult(centers, weights, iter, δ <= tol)

--- a/src/fuzzycmeans.jl
+++ b/src/fuzzycmeans.jl
@@ -73,8 +73,8 @@ Perform Fuzzy C-means clustering over the given `data`.
  - `data::AbstractMatrix`: ``d×n`` data matrix. Each column represents
    one ``d``-dimensional data point.
  - `C::Int`: the number of fuzzy clusters, ``2 ≤ C < n``.
- - `fuzziness::Real`: clusters fuzziness (see ``m`` in the
-   [mathematical formulation](@ref fuzzy_cmeans_def)), ``\\mathrm{fuzziness} > 1``.
+ - `fuzziness::Real`: clusters fuzziness (``μ`` in the
+   [mathematical formulation](@ref fuzzy_cmeans_def)), ``μ > 1``.
 
 Optional keyword arguments:
  - `dist_metric::Metric` (defaults to `Euclidean`): the `Metric` object

--- a/src/fuzzycmeans.jl
+++ b/src/fuzzycmeans.jl
@@ -64,54 +64,53 @@ const _fcmeans_default_tol = 1.0e-3
 const _fcmeans_default_display = :none
 
 """
-    fuzzy_cmeans(data::AbstractMatrix, C::Int, fuzziness::Real,
-                 [...]) -> FuzzyCMeansResult
+    fuzzy_cmeans(data::AbstractMatrix, C::Integer, fuzziness::Real;
+                 [dist_metric::SemiMetric], [...]) -> FuzzyCMeansResult
 
 Perform Fuzzy C-means clustering over the given `data`.
 
 # Arguments
  - `data::AbstractMatrix`: ``d×n`` data matrix. Each column represents
    one ``d``-dimensional data point.
- - `C::Int`: the number of fuzzy clusters, ``2 ≤ C < n``.
+ - `C::Integer`: the number of fuzzy clusters, ``2 ≤ C < n``.
  - `fuzziness::Real`: clusters fuzziness (``μ`` in the
    [mathematical formulation](@ref fuzzy_cmeans_def)), ``μ > 1``.
 
 Optional keyword arguments:
- - `dist_metric::Metric` (defaults to `Euclidean`): the `Metric` object
+ - `dist_metric::SemiMetric` (defaults to `Euclidean`): the `SemiMetric` object
     that defines the distance between the data points
- - `maxiter`, `tol`, `display`: see [common options](@ref common_options)
+ - `maxiter`, `tol`, `display`, `rng`: see [common options](@ref common_options)
 """
 function fuzzy_cmeans(
-    data::AbstractMatrix{T},
-    C::Int,
+    data::AbstractMatrix{<:Real},
+    C::Integer,
     fuzziness::Real;
-    maxiter::Int = _fcmeans_default_maxiter,
+    maxiter::Integer = _fcmeans_default_maxiter,
     tol::Real = _fcmeans_default_tol,
-    dist_metric::Metric = Euclidean(),
+    dist_metric::SemiMetric = Euclidean(),
     display::Symbol = _fcmeans_default_display,
     rng::AbstractRNG = Random.GLOBAL_RNG
-    ) where T<:Real
-
+)
     nrows, ncols = size(data)
     2 <= C < ncols || throw(ArgumentError("C must have 2 <= C < n=$ncols ($C given)"))
     1 < fuzziness || throw(ArgumentError("fuzziness must be greater than 1 ($fuzziness given)"))
 
-    _fuzzy_cmeans(data, C, fuzziness, maxiter, tol, dist_metric, display_level(display),rng)
-
+    _fuzzy_cmeans(data, C, fuzziness,
+                  maxiter, tol, dist_metric, display_level(display), rng)
 end
 
 ## Core implementation
 
 function _fuzzy_cmeans(
     data::AbstractMatrix{T},                        # data matrix
-    C::Int,                                         # total number of classes
+    C::Integer,                                     # total number of classes
     fuzziness::Real,                                # fuzziness
     maxiter::Int,                                   # maximum number of iterations
     tol::Real,                                      # tolerance
-    dist_metric::Metric,                            # metric to calculate distance
+    dist_metric::SemiMetric,                        # metric to calculate distance
     displevel::Int,                                 # the level of display
     rng::AbstractRNG                                # RNG object
-    ) where T<:Real
+) where T<:Real
 
     nrows, ncols = size(data)
 

--- a/src/fuzzycmeans.jl
+++ b/src/fuzzycmeans.jl
@@ -129,7 +129,7 @@ function _fuzzy_cmeans(
         println("----------------------------")
     end
 
-    while iter < maxiter && δ > tol
+    while iter < maxiter && (iter <= 1 || δ > tol) # skip tol test for iter=1 since prev_centers are not relevant
         update_centers!(centers, data, weights, fuzziness)
         update_weights!(weights, data, centers, fuzziness, dist_metric)
         δ = maximum(colwise(dist_metric, prev_centers, centers))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -60,7 +60,8 @@ assignments(A::ClusterAssignments) = A
 const DisplayLevels = Dict(:none => 0, :final => 1, :iter => 2)
 
 display_level(s::Symbol) = get(DisplayLevels, s) do
-    throw(ArgumentError("Invalid value for the 'display' option: $s."))
+    valid_vals = string.(":", first.(sort!(collect(pairs(DisplayLevels)), by=last)))
+    throw(ArgumentError("Invalid option display=:$s ($(join(valid_vals, ", ", ", or ")) expected)"))
 end
 
 ##### update minimum value

--- a/test/fuzzycmeans.jl
+++ b/test/fuzzycmeans.jl
@@ -26,6 +26,7 @@ x = rand(rng, d, n)
 @testset "fuzziness = 2.0" begin
     fuzziness = 2.0
     Random.seed!(rng, 34568)
+    @test_logs (:warn, r"^Fuzzy C-means terminated without convergence") fuzzy_cmeans(x, k, fuzziness; maxiter=1, rng=rng)
     r = fuzzy_cmeans(x, k, fuzziness; rng=rng)
     @test isa(r, FuzzyCMeansResult{Float64})
     @test nclusters(r) == k


### PR DESCRIPTION
* allow `dist_metric::SemiMetric`
* skip tolerance check for the 1st iteration (`prev_centers` are initialized to all zeroes, so it is not relevant to compare, and some metrics (e.g. `CorrDist`) are NaN in this case) 
* more informative error message if `display=` is specified incorrectly
* tweak `fuzzycmeans()` docs